### PR TITLE
Specify Locale for toLowerCase for non-english PCs

### DIFF
--- a/src/main/java/io/github/noeppi_noeppi/libx/config/ConfigManager.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/config/ConfigManager.java
@@ -151,7 +151,7 @@ public class ConfigManager {
             AdvancedValueMappers.INGREDIENT_STACK
             ).stream().collect(ImmutableMap.toImmutableMap(ValueMapper::type, Function.identity()));
     @SuppressWarnings("UnstableApiUsage")
-    private static final Map<Class<?>, ResourceLocation> globalMappersToRL = globalMappers.keySet().stream().map(key -> Pair.of(key, new ResourceLocation("minecraft", ClassUtil.boxed(key).getSimpleName().toLowerCase(Locale.ENGLISH)))).collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue));
+    private static final Map<Class<?>, ResourceLocation> globalMappersToRL = globalMappers.keySet().stream().map(key -> Pair.of(key, new ResourceLocation("minecraft", ClassUtil.boxed(key).getSimpleName().toLowerCase(Locale.ROOT)))).collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue));
     private static final Map<ResourceLocation, ValueMapper<?, ?>> mappers = Collections.synchronizedMap(new HashMap<>());
     
     @SuppressWarnings("UnstableApiUsage")

--- a/src/main/java/io/github/noeppi_noeppi/libx/config/ConfigManager.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/config/ConfigManager.java
@@ -151,7 +151,7 @@ public class ConfigManager {
             AdvancedValueMappers.INGREDIENT_STACK
             ).stream().collect(ImmutableMap.toImmutableMap(ValueMapper::type, Function.identity()));
     @SuppressWarnings("UnstableApiUsage")
-    private static final Map<Class<?>, ResourceLocation> globalMappersToRL = globalMappers.keySet().stream().map(key -> Pair.of(key, new ResourceLocation("minecraft", ClassUtil.boxed(key).getSimpleName().toLowerCase()))).collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue));
+    private static final Map<Class<?>, ResourceLocation> globalMappersToRL = globalMappers.keySet().stream().map(key -> Pair.of(key, new ResourceLocation("minecraft", ClassUtil.boxed(key).getSimpleName().toLowerCase(Locale.ENGLISH)))).collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue));
     private static final Map<ResourceLocation, ValueMapper<?, ?>> mappers = Collections.synchronizedMap(new HashMap<>());
     
     @SuppressWarnings("UnstableApiUsage")


### PR DESCRIPTION
Should hopefully fix https://github.com/noeppi-noeppi/LibX/issues/10

Java's documentation says

> This method is locale sensitive, and may produce unexpected results if used for strings that are intended to be interpreted locale independently. Examples are programming language identifiers, protocol keys, and HTML tags. For instance, "TITLE".toLowerCase() in a Turkish locale returns "tıtle", where 'ı' is the LATIN SMALL LETTER DOTLESS I character. To obtain correct results for locale insensitive strings, use toLowerCase(Locale.ENGLISH).