### PR TITLE
Registry Tracking

### DIFF
--- a/src/main/java/io/github/noeppi_noeppi/libx/impl/reflect/ReflectionHacks.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/impl/reflect/ReflectionHacks.java
@@ -1,0 +1,72 @@
+package io.github.noeppi_noeppi.libx.impl.reflect;
+
+import io.github.noeppi_noeppi.libx.util.LazyValue;
+import sun.misc.Unsafe;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+public class ReflectionHacks {
+    
+    private static final LazyValue<Unsafe> unsafe = new LazyValue<>(() -> {
+        try {
+            Field field = Unsafe.class.getDeclaredField("theUnsafe");
+            field.setAccessible(true);
+            return (Unsafe) field.get(null);
+        } catch (Exception e) {
+            throw new IllegalStateException("ReflectionHacks: Can't retrieve the unsafe.", e);
+        }
+    });
+    
+    public static void setFinalField(Field field, Object instance, @Nullable Object value) {
+        Object base;
+        long offset;
+        if (Modifier.isStatic(field.getModifiers())) {
+            base = unsafe.get().staticFieldBase(field);
+            offset = unsafe.get().staticFieldOffset(field);
+        } else {
+            if (instance == null) {
+                throw new NullPointerException("No instance for non-static field: " + field);
+            } else if (!field.getDeclaringClass().isAssignableFrom(instance.getClass())) {
+                throw new IllegalArgumentException("Instance has wrong type for field: " + instance + " " + field);
+            } else {
+                base = instance;
+                offset = unsafe.get().objectFieldOffset(field);
+            }
+        }
+        if (field.getType() == void.class) {
+            throw new IllegalStateException("Field with void type");
+        } else if (field.getDeclaringClass().isEnum() && Modifier.isStatic(field.getModifiers())) {
+            throw new IllegalStateException("Can't change enum field");
+        } else if (field.getType() == boolean.class) {
+            if (value == null) throw new NullPointerException("Null primitive for field: " + field);
+            unsafe.get().putBooleanVolatile(base, offset, (Boolean) value);
+        } else if (field.getType() == byte.class) {
+            if (value == null) throw new NullPointerException("Null primitive for field: " + field);
+            unsafe.get().putByteVolatile(base, offset, (Byte) value);
+        } else if (field.getType() == char.class) {
+            if (value == null) throw new NullPointerException("Null primitive for field: " + field);
+            unsafe.get().putCharVolatile(base, offset, (Character) value);
+        } else if (field.getType() == short.class) {
+            if (value == null) throw new NullPointerException("Null primitive for field: " + field);
+            unsafe.get().putShortVolatile(base, offset, (Short) value);
+        } else if (field.getType() == int.class) {
+            if (value == null) throw new NullPointerException("Null primitive for field: " + field);
+            unsafe.get().putIntVolatile(base, offset, (Integer) value);
+        } else if (field.getType() == long.class) {
+            if (value == null) throw new NullPointerException("Null primitive for field: " + field);
+            unsafe.get().putLongVolatile(base, offset, (Long) value);
+        } else if (field.getType() == float.class) {
+            if (value == null) throw new NullPointerException("Null primitive for field: " + field);
+            unsafe.get().putFloatVolatile(base, offset, (Float) value);
+        } else if (field.getType() == double.class) {
+            if (value == null) throw new NullPointerException("Null primitive for field: " + field);
+            unsafe.get().putDoubleVolatile(base, offset, (Double) value);
+        } else if (value != null && !field.getType().isAssignableFrom(value.getClass())) {
+            throw new ClassCastException("Expected value of type " + field.getType() + " for field " + field + ", got " + value.getClass());
+        } else {
+            unsafe.get().putObjectVolatile(base, offset, value);
+        }
+    }
+}

--- a/src/main/java/io/github/noeppi_noeppi/libx/mod/registration/RegistryTracker.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/mod/registration/RegistryTracker.java
@@ -1,0 +1,110 @@
+package io.github.noeppi_noeppi.libx.mod.registration;
+
+import io.github.noeppi_noeppi.libx.LibX;
+import io.github.noeppi_noeppi.libx.annotation.meta.Experimental;
+import io.github.noeppi_noeppi.libx.impl.reflect.ReflectionHacks;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.registries.IForgeRegistry;
+import net.minecraftforge.registries.IForgeRegistryEntry;
+import net.minecraftforge.registries.ObjectHolderRegistry;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+/**
+ * Provides a way to track the values of fields with a registry object. That means if the registry object is
+ * replaced, the field is updated.
+ */
+@Experimental
+public class RegistryTracker {
+
+    private static final Object LOCK = new Object();
+    
+    private static final Map<ResourceLocation, RegistryData<?>> trackedRegistries = new HashMap<>();
+    private static final Set<Field> trackedFields = new HashSet<>();
+
+    /**
+     * Add a field to the list of tracked fields. It will then be updated whenever the registry value changes.
+     * This will not ensure the field holds the value matching the registry at the time, the method is called.
+     * 
+     * @param registry The registry used to track the field.
+     * @param field The field to track.
+     * @param id The {@link ResourceLocation} used for registering the object
+     */
+    public static <T extends IForgeRegistryEntry<T>> void trackField(IForgeRegistry<T> registry, Field field, ResourceLocation id) {
+        synchronized (LOCK) {
+            if (trackedFields.contains(field)) {
+                throw new IllegalStateException("Can't track registry element field: Field already tracked: " + field);
+            }
+            trackedFields.add(field);
+            trackedRegistries.computeIfAbsent(registry.getRegistryName(), key -> {
+                RegistryData<T> data = new RegistryData<>(registry);
+                ObjectHolderRegistry.addHandler(data);
+                return data;
+            }).add(id, field);
+        }
+    }
+
+    private static final class RegistryData<T extends IForgeRegistryEntry<T>> implements Consumer<Predicate<ResourceLocation>> {
+
+        public final ResourceLocation registryId;
+        public final IForgeRegistry<T> registry;
+        private final List<Pair<ResourceLocation, Field>> entries;
+
+        private RegistryData(IForgeRegistry<T> registry) {
+            this.registryId = registry.getRegistryName();
+            this.registry = registry;
+            this.entries = new ArrayList<>();
+        }
+
+        public void add(ResourceLocation id, Field field) {
+            if (!Modifier.isStatic(field.getModifiers())) {
+                throw new IllegalStateException("Can't track registry element field: Must be static: " + field);
+            } if (!this.registry.getRegistrySuperType().isAssignableFrom(field.getType())) {
+                throw new IllegalStateException("Can't track registry element field: Has type " + field.getType() + ", expected " + this.registry.getRegistrySuperType() + " for value of registry " + this.registryId);
+            } else {
+                this.entries.add(Pair.of(id, field));
+            }
+        }
+
+        @Override
+        public void accept(Predicate<ResourceLocation> changed) {
+            if (changed.test(this.registryId)) {
+                for (Pair<ResourceLocation, Field> entry : this.entries) {
+                    try {
+                        //noinspection unchecked
+                        T oldValue = (T) entry.getValue().get(null);
+                        T value = this.registry.getValue(entry.getKey());
+                        if (value == null) {
+                            throw new IllegalStateException("Tracked registry object not present: " + this.registryId + " / " + entry.getKey() + ", was " + oldValue + " before.");
+                        } else if (entry.getValue().getType().isAssignableFrom(value.getClass())) {
+                            throw new IllegalStateException("Tracked registry object has invalid type: " + this.registryId + " / " + entry.getKey() + ", was " + oldValue + " before. Probably a failed registry replacement.");
+                        } else if (value != oldValue) {
+                            if (Modifier.isFinal(entry.getValue().getModifiers())) {
+                                try {
+                                    ReflectionHacks.setFinalField(entry.getValue(), null, value);
+                                } catch (Exception e) {
+                                    throw new ReflectiveOperationException("Failed to set final tracked registry field " + entry.getValue(), e);
+                                }
+                            } else {
+                                entry.getValue().setAccessible(true);
+                                entry.getValue().set(null, value);
+                            }
+                        }
+                    } catch (ReflectiveOperationException e) {
+                        LibX.logger.error("Failed to update registry object: " + this.registryId + " / " + entry.getKey(), e);
+                    }
+                }
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return this.registryId.hashCode();
+        }
+    }
+}

--- a/src/test/java/io/github/noeppi_noeppi/libx/test/ReflectionHacksTest.java
+++ b/src/test/java/io/github/noeppi_noeppi/libx/test/ReflectionHacksTest.java
@@ -1,0 +1,59 @@
+package io.github.noeppi_noeppi.libx.test;
+
+import io.github.noeppi_noeppi.libx.impl.reflect.ReflectionHacks;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ReflectionHacksTest {
+    
+    public static final WrappedString staticField = new WrappedString("Hello, world!");
+    
+    @Test
+    public void testClasses() throws Throwable {
+        A a = new A("aaa", 42);
+        B b = new B("bbb");
+        
+        ReflectionHacks.setFinalField(ReflectionHacksTest.class.getField("staticField"), null, new WrappedString("Changed!"));
+        assertEquals(new WrappedString("Changed!"), staticField, "Static final field was not changed.");
+        
+        ReflectionHacks.setFinalField(A.class.getField("field"), a, "Changed!");
+        assertEquals("Changed!", a.field, "Final instance field was not changed.");
+
+        ReflectionHacks.setFinalField(A.class.getField("primitive"), a, 17);
+        assertEquals(17, a.primitive, "Primitive final instance field was not changed.");
+        
+        ReflectionHacks.setFinalField(A.class.getField("field"), a, null);
+        assertNull(a.field, "Static final field was not changed.");
+        
+        assertThrows(NullPointerException.class, () -> ReflectionHacks.setFinalField(A.class.getField("field"), null, ""));
+        assertThrows(IllegalArgumentException.class, () -> ReflectionHacks.setFinalField(A.class.getField("field"), b, ""));
+        assertThrows(NullPointerException.class, () -> ReflectionHacks.setFinalField(A.class.getField("primitive"), a, null));
+        assertThrows(ClassCastException.class, () -> ReflectionHacks.setFinalField(A.class.getField("field"), a, new Date()));
+    }
+    
+    private static class A {
+        
+        public final String field;
+        public final int primitive;
+
+        private A(String field, int primitive) {
+            this.field = field;
+            this.primitive = primitive;
+        }
+    }
+    
+    private static class B {
+        
+        public final String field;
+
+        private B(String field) {
+            this.field = field;
+        }
+    }
+    
+    // Can't use strings in static final fields as they are inlined by the compiler.
+    private record WrappedString(String value) {}
+}


### PR DESCRIPTION
Draft for registry tracking. Can hopefully be integrated with ModInit later, so the LibX registration system can work with registry replacements.

However, uses the `Unsafe` at the moment to set final fields. It needs to be discussed, how exactly this should be implemented and whether setting final fields should be supported.