### PR TITLE
Deprecate the instance logger

### DIFF
--- a/src/main/java/io/github/noeppi_noeppi/libx/LibX.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/LibX.java
@@ -35,12 +35,16 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * LibX instance class.
  */
 @Mod("libx")
 public final class LibX extends ModX {
+    
+    public static final Logger logger = LoggerFactory.getLogger("libx");
     
     private static LibX instance;
     private static CommonNetwork networkWrapper;

--- a/src/main/java/io/github/noeppi_noeppi/libx/command/EnumArgument2.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/command/EnumArgument2.java
@@ -83,7 +83,7 @@ public class EnumArgument2<T extends Enum<T>> implements ArgumentType<T> {
             try {
                 return new EnumArgument2(Class.forName(name));
             } catch (ClassNotFoundException e) {
-                LibX.getInstance().logger.warn("Can't get enum value of type " + name + "in command argument. " + e.getMessage());
+                LibX.logger.warn("Can't get enum value of type " + name + "in command argument. " + e.getMessage());
                 //noinspection ConstantConditions
                 return null;
             }

--- a/src/main/java/io/github/noeppi_noeppi/libx/config/ConfigManager.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/config/ConfigManager.java
@@ -250,7 +250,7 @@ public class ConfigManager {
                 MinecraftForge.EVENT_BUS.post(new ConfigLoadedEvent(config.id, config.baseClass, ConfigLoadedEvent.LoadReason.INITIAL, config.clientConfig, config.path, config.path));
             }
         } catch (IOException | IllegalStateException | JsonParseException e) {
-            LibX.getInstance().logger.error("Failed to load config '" + configIds.inverse().get(configClass) + "' (class: " + configClass + ")", e);
+            LibX.logger.error("Failed to load config '" + configIds.inverse().get(configClass) + "' (class: " + configClass + ")", e);
         }
     }
 
@@ -280,7 +280,7 @@ public class ConfigManager {
                 }
             }
         } catch (IOException | IllegalStateException | JsonParseException e) {
-            LibX.getInstance().logger.error("Failed to reload config '" + configIds.inverse().get(configClass) + "' (class: " + configClass + ")", e);
+            LibX.logger.error("Failed to reload config '" + configIds.inverse().get(configClass) + "' (class: " + configClass + ")", e);
         }
     }
 
@@ -299,7 +299,7 @@ public class ConfigManager {
                 NetworkImpl.getImpl().channel.send(target, new ConfigShadowSerializer.ConfigShadowMessage(config, config.cachedOrCurrent()));
             }
         } else {
-            LibX.getInstance().logger.error("ConfigManager.forceResync was called on a physical client. Ignoring.");
+            LibX.logger.error("ConfigManager.forceResync was called on a physical client. Ignoring.");
         }
     }
 
@@ -316,7 +316,7 @@ public class ConfigManager {
                 }
             }
         } else {
-            LibX.getInstance().logger.error("ConfigManager.forceResync was called on a physical client. Ignoring.");
+            LibX.logger.error("ConfigManager.forceResync was called on a physical client. Ignoring.");
         }
     }
 

--- a/src/main/java/io/github/noeppi_noeppi/libx/impl/config/ConfigImpl.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/impl/config/ConfigImpl.java
@@ -140,7 +140,7 @@ public class ConfigImpl {
                 keysLeft.remove(key);
             }
             if (!keysLeft.isEmpty()) {
-                LibX.getInstance().logger.warn("Config " + this.id + ": There are additional fields on the client, not sent by the server. Using client values.");
+                LibX.logger.warn("Config " + this.id + ": There are additional fields on the client, not sent by the server. Using client values.");
             }
             return new ConfigState(this, values.build());
         } catch (ReflectiveOperationException e) {
@@ -157,7 +157,7 @@ public class ConfigImpl {
     
     public ConfigState readFromFileOrCreateBy(ConfigState state) throws IOException {
         if (!Files.isRegularFile(this.path)) {
-            LibX.getInstance().logger.info("Config '" + this.id + "' does not exist. Creating default.");
+            LibX.logger.info("Config '" + this.id + "' does not exist. Creating default.");
             state.writeToFile(null, null);
             return state;
         } else {
@@ -202,7 +202,7 @@ public class ConfigImpl {
                     if (value == null) throw new IllegalStateException("Config mapper reported null value.");
                     values.put(key, key.validate(value, "Invalid value in config file", needsCorrection));
                 } catch (Exception e) {
-                    LibX.getInstance().logger.warn("Failed to read config value " + String.join(".", key.path) + ". Correcting. Error: " + e.getMessage());
+                    LibX.logger.warn("Failed to read config value " + String.join(".", key.path) + ". Correcting. Error: " + e.getMessage());
                     CorrectionInstance<?, ?> correction = CorrectionInstance.create(parentConfig.getValue(key));
                     //noinspection unchecked
                     Object value = correction.correct(elem, (ValueMapper<Object, ?>) key.mapper, o -> o).orElse(parentConfig.getValue(key));
@@ -224,9 +224,9 @@ public class ConfigImpl {
         ConfigState state = new ConfigState(this, values.build());
         if (needsCorrection.get()) {
             if (path != null) {
-                LibX.getInstance().logger.info("Correcting config '" + this.id + "' at " + path.toAbsolutePath().normalize());
+                LibX.logger.info("Correcting config '" + this.id + "' at " + path.toAbsolutePath().normalize());
             } else {
-                LibX.getInstance().logger.info("Correcting config '" + this.id + "'");
+                LibX.logger.info("Correcting config '" + this.id + "'");
             }
             state.writeToFile(path, keysToCorrect);
         }
@@ -286,10 +286,10 @@ public class ConfigImpl {
     
     private void shadowBy(ConfigState state, boolean local, @Nullable Path loadPath) {
         if (FMLEnvironment.dist == Dist.DEDICATED_SERVER) {
-            LibX.getInstance().logger.error("Config shadow was called on a dedicated server. This should not happen!");
+            LibX.logger.error("Config shadow was called on a dedicated server. This should not happen!");
         }
         if (!this.shadowed && this.savedState == null) {
-            LibX.getInstance().logger.warn("Capturing config state for '" + this.id + "' before shadowing. This should not happen. Was the config not loaded properly?");
+            LibX.logger.warn("Capturing config state for '" + this.id + "' before shadowing. This should not happen. Was the config not loaded properly?");
             this.savedState = this.stateFromValues();
         }
         this.shadowed = true;
@@ -303,7 +303,7 @@ public class ConfigImpl {
         if (this.shadowed && this.savedState != null) {
             this.savedState.apply();
         } else if (this.shadowed) {
-            LibX.getInstance().logger.warn("Could not restore config: No saved state");
+            LibX.logger.warn("Could not restore config: No saved state");
         }
         this.shadowed = false;
         this.shadowedLocal = false;
@@ -319,7 +319,7 @@ public class ConfigImpl {
                     Path configDir = server.storageSource.getWorldDir().resolve("config");
                     Path configPath = resolveConfigPath(configDir, this.id);
                     if (this.savedState == null) {
-                        LibX.getInstance().logger.warn("Can't load world specific config for '" + this.id + "': No captured state. This should never happen.");
+                        LibX.logger.warn("Can't load world specific config for '" + this.id + "': No captured state. This should never happen.");
                     } else {
                         try {
                             if (Files.isRegularFile(configPath)) {
@@ -327,7 +327,7 @@ public class ConfigImpl {
                                 this.shadowBy(state, true, configPath);
                             }
                         } catch (IOException e) {
-                            LibX.getInstance().logger.warn("Can't load world specific config for '" + this.id + "': " + e.getMessage());
+                            LibX.logger.warn("Can't load world specific config for '" + this.id + "': " + e.getMessage());
                             e.printStackTrace();
                         }
                     }
@@ -354,7 +354,7 @@ public class ConfigImpl {
         try {
             newState.writeToFile(null, null);
         } catch (IOException e) {
-            LibX.getInstance().logger.warn("Failed to save config file from InGame values: " + e.getMessage(), e);
+            LibX.logger.warn("Failed to save config file from InGame values: " + e.getMessage(), e);
         }
     }
     
@@ -371,10 +371,10 @@ public class ConfigImpl {
 
     public ConfigState cachedOrCurrent() {
         if (FMLEnvironment.dist != Dist.DEDICATED_SERVER) {
-            LibX.getInstance().logger.error("Config cached or current method was called on a physical client. This should not happen!");
+            LibX.logger.error("Config cached or current method was called on a physical client. This should not happen!");
         }
         if (this.savedState == null) {
-            LibX.getInstance().logger.warn("Capturing config state for '" + this.id + "' on server. This should not happen. Was the config not loaded properly?");
+            LibX.logger.warn("Capturing config state for '" + this.id + "' on server. This should not happen. Was the config not loaded properly?");
             this.savedState = this.stateFromValues();
         }
         return this.savedState;

--- a/src/main/java/io/github/noeppi_noeppi/libx/impl/config/ModMappers.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/impl/config/ModMappers.java
@@ -105,7 +105,7 @@ public class ModMappers {
             throw new IllegalStateException("Config mapper for type '" + mapper.type() + "' is already registered.");
         } else {
             if (globalMappers.containsKey(mapper.type())) {
-                LibX.getInstance().logger.warn(this.modid + " registers a custom value mapper for type " + mapper.type() + " even if there's a builtin one. This is discouraged.");
+                LibX.logger.warn(this.modid + " registers a custom value mapper for type " + mapper.type() + " even if there's a builtin one. This is discouraged.");
             }
             this.mappers.put(mapper.type(), mapper);
         }

--- a/src/main/java/io/github/noeppi_noeppi/libx/impl/config/gui/ConfigDisplay.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/impl/config/gui/ConfigDisplay.java
@@ -45,7 +45,7 @@ public class ConfigDisplay {
             if (entry.getKey().mapper.type().isAssignableFrom(value.getClass())) {
                 map.put(entry.getKey(), value);
             } else {
-                LibX.getInstance().logger.warn("Failed to create config state from user input: Editor produced invalid type. Expected: " + entry.getKey().mapper.type() + ", Got: " + value.getClass() + ", using fallback.");
+                LibX.logger.warn("Failed to create config state from user input: Editor produced invalid type. Expected: " + entry.getKey().mapper.type() + ", Got: " + value.getClass() + ", using fallback.");
                 map.put(entry.getKey(), entry.getValue().defaultValue);
             }
         }
@@ -93,7 +93,7 @@ public class ConfigDisplay {
 
         public void setValue(T value) {
             if (!this.key.mapper.type().isAssignableFrom(value.getClass())) {
-                LibX.getInstance().logger.warn("Failed to store config value from user input: Editor produced invalid type. Expected: " + this.key.mapper.type() + ", Got: " + value.getClass() + ", ignoring.");
+                LibX.logger.warn("Failed to store config value from user input: Editor produced invalid type. Expected: " + this.key.mapper.type() + ", Got: " + value.getClass() + ", ignoring.");
             } else {
                 if (this.value != value) {
                     //noinspection unchecked

--- a/src/main/java/io/github/noeppi_noeppi/libx/impl/config/validators/ConfiguredValidator.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/impl/config/validators/ConfiguredValidator.java
@@ -23,7 +23,7 @@ public class ConfiguredValidator<T, A extends Annotation> {
     public T validate(T value, String action, List<String> path, @Nullable AtomicBoolean needsCorrection) {
         Optional<T> result = this.validator.validate(value, this.annotation);
         if (result.isPresent()) {
-            LibX.getInstance().logger.warn(action + ". Corrected value " + String.join(".", path) + " from " + value + " to " + result.get() + ".");
+            LibX.logger.warn(action + ". Corrected value " + String.join(".", path) + " from " + value + " to " + result.get() + ".");
             if (needsCorrection != null) {
                 needsCorrection.set(true);
             }

--- a/src/main/java/io/github/noeppi_noeppi/libx/impl/datapack/DynamicDatapackLocator.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/impl/datapack/DynamicDatapackLocator.java
@@ -41,7 +41,7 @@ public class DynamicDatapackLocator implements RepositorySource {
             String name = LibXDatapack.PREFIX + "/" + id.getNamespace() + ":" + id.getPath();
             IModFileInfo fileInfo = ModList.get().getModFileById(id.getNamespace());
             if (fileInfo == null || fileInfo.getFile() == null) {
-                LibX.getInstance().logger.warn("Can't create dynamic datapack " + id + ": Invalid mod file: " + fileInfo);
+                LibX.logger.warn("Can't create dynamic datapack " + id + ": Invalid mod file: " + fileInfo);
             } else {
                 Pack pack = Pack.create(name, false,
                         () -> new LibXDatapack(fileInfo.getFile(), id.getPath()), factory,

--- a/src/main/java/io/github/noeppi_noeppi/libx/impl/datapack/LibXDatapack.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/impl/datapack/LibXDatapack.java
@@ -50,7 +50,7 @@ public class LibXDatapack extends PathResourcePack {
         // cpw said everything would be open. Now sjh isn't.
         // Well reflection does the trick.
         if ("cpw.mods.niofs.union.UnionPath".equals(path.getClass().getName())) {
-            LibX.getInstance().logger.warn("A LibX datapack was created with a UnionPath. These are currently buggy. See https://github.com/MinecraftForge/securejarhandler/pull/4");
+            LibX.logger.warn("A LibX datapack was created with a UnionPath. These are currently buggy. See https://github.com/MinecraftForge/securejarhandler/pull/4");
             // hacky workaround that should keep things working:
             String pathStr = path.toString();
             if (pathStr.startsWith("/") || pathStr.startsWith(File.separator)) {

--- a/src/main/java/io/github/noeppi_noeppi/libx/impl/network/ConfigShadowSerializer.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/impl/network/ConfigShadowSerializer.java
@@ -30,12 +30,12 @@ public class ConfigShadowSerializer implements PacketSerializer<ConfigShadowSeri
         ConfigImpl config = ConfigImpl.getConfigNullable(configId);
         int size = buffer.readVarInt();
         if (config == null) {
-            LibX.getInstance().logger.warn("Received shadow message for unknown config: '" + configId + "'. Ignoring");
+            LibX.logger.warn("Received shadow message for unknown config: '" + configId + "'. Ignoring");
             // Skip the bytes we don't know about.
             buffer.skipBytes(size);
             return new ConfigShadowMessage(null, null);
         } else if (config.clientConfig) {
-            LibX.getInstance().logger.warn("Received shadow message for not-synced config: '" + configId + "'. Ignoring");
+            LibX.logger.warn("Received shadow message for not-synced config: '" + configId + "'. Ignoring");
             // Skip the bytes we don't know about.
             buffer.skipBytes(size);
             return new ConfigShadowMessage(null, null);

--- a/src/main/java/io/github/noeppi_noeppi/libx/menu/GenericMenu.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/menu/GenericMenu.java
@@ -52,7 +52,7 @@ public class GenericMenu extends MenuBase {
         if (validators.containsKey(validatorId)) {
             validator = validators.get(validatorId);
         } else {
-            LibX.getInstance().logger.warn("Received invalid validator for generic container. Validator: " + validatorId);
+            LibX.logger.warn("Received invalid validator for generic container. Validator: " + validatorId);
             validator = validators.get(EMPTY_VALIDATOR);
         }
         int[] slotLimits = new int[size];
@@ -153,7 +153,7 @@ public class GenericMenu extends MenuBase {
                 if (validators.containsKey(validatorId == null ? EMPTY_VALIDATOR : validatorId)) {
                     validator = validators.get(validatorId);
                 } else {
-                    LibX.getInstance().logger.warn("Generic container created with invalid validator. Validator ID: " + validatorId);
+                    LibX.logger.warn("Generic container created with invalid validator. Validator ID: " + validatorId);
                     validator = validators.get(EMPTY_VALIDATOR);
                 }
                 return new GenericMenu(containerId, new GenericContainerSlotValidationWrapper(inventory, validator, null), inv);

--- a/src/main/java/io/github/noeppi_noeppi/libx/mod/ModX.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/mod/ModX.java
@@ -1,5 +1,6 @@
 package io.github.noeppi_noeppi.libx.mod;
 
+import io.github.noeppi_noeppi.libx.annotation.meta.RemoveIn;
 import io.github.noeppi_noeppi.libx.impl.ModInternal;
 import io.github.noeppi_noeppi.libx.impl.config.ModMappers;
 import io.github.noeppi_noeppi.libx.mod.registration.ModXRegistration;
@@ -30,7 +31,11 @@ public abstract class ModX {
 
     /**
      * A {@link Logger} for the mod.
+     * @deprecated The logger is hard to use and causes problems during parallel mod initialisation.
+     *             You should create your own logger for your mod.
      */
+    @Deprecated(forRemoval = true)
+    @RemoveIn(minecraft = "1.19")
     public final Logger logger;
 
     /**

--- a/src/main/java/io/github/noeppi_noeppi/libx/util/ResourceList.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/util/ResourceList.java
@@ -119,7 +119,7 @@ public class ResourceList implements Predicate<ResourceLocation> {
             try {
                 rules.add(this.parseRule(elem));
             } catch (IllegalStateException e) {
-                LibX.getInstance().logger.warn("Skipping invalid rule in resource list: " + e.getMessage());
+                LibX.logger.warn("Skipping invalid rule in resource list: " + e.getMessage());
             }
         }
         this.rules = rules.build();


### PR DESCRIPTION
This schedules the logger that is created for each `ModX` instance for removal. 
Reasons for this:
  * It was too much boilerplate to be used.
  * LibX never used the logger of other `ModX` instances so no comman value for this is required
  * It causes issues during parallel mod loading.