### PR TITLE
small changes

### DIFF
--- a/src/main/java/io/github/noeppi_noeppi/libx/datapack/DataLoader.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/datapack/DataLoader.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
+import net.minecraft.Util;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.server.packs.resources.ResourceManager;
@@ -23,7 +24,7 @@ import java.util.stream.Stream;
  */
 public class DataLoader {
 
-    private static final Gson GSON = net.minecraft.Util.make(() -> {
+    private static final Gson GSON = Util.make(() -> {
         GsonBuilder builder = new GsonBuilder();
         builder.disableHtmlEscaping();
         builder.setLenient();

--- a/src/main/java/io/github/noeppi_noeppi/libx/impl/config/ConfigImpl.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/impl/config/ConfigImpl.java
@@ -11,6 +11,7 @@ import io.github.noeppi_noeppi.libx.config.ValueMapper;
 import io.github.noeppi_noeppi.libx.event.ConfigLoadedEvent;
 import io.github.noeppi_noeppi.libx.impl.config.correct.CorrectionInstance;
 import io.github.noeppi_noeppi.libx.impl.config.gui.ConfigDisplay;
+import net.minecraft.Util;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
@@ -33,7 +34,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class ConfigImpl {
 
-    public static final Gson GSON = net.minecraft.Util.make(() -> {
+    public static final Gson GSON = Util.make(() -> {
         GsonBuilder builder = new GsonBuilder();
         builder.disableHtmlEscaping();
         builder.setLenient();
@@ -41,7 +42,7 @@ public class ConfigImpl {
         return builder.create();
     });
 
-    public static final Gson INTERNAL = net.minecraft.Util.make(() -> {
+    public static final Gson INTERNAL = Util.make(() -> {
         GsonBuilder builder = new GsonBuilder();
         builder.disableHtmlEscaping();
         return builder.create();

--- a/src/main/java/io/github/noeppi_noeppi/libx/impl/config/gui/editor/OptionEditor.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/impl/config/gui/editor/OptionEditor.java
@@ -87,5 +87,10 @@ public class OptionEditor<T> implements ConfigEditor<Optional<T>> {
             }
             this.inputChanged.accept(this.box.selected() ? Optional.of(this.value) : Optional.empty());
         }
+
+        @Override
+        public void enabled(boolean enabled) {
+            EditorOps.wrap(this.box).enabled(enabled);
+        }
     }
 }

--- a/src/main/java/io/github/noeppi_noeppi/libx/impl/config/gui/screen/content/component/ComponentContent.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/impl/config/gui/screen/content/component/ComponentContent.java
@@ -2,6 +2,7 @@ package io.github.noeppi_noeppi.libx.impl.config.gui.screen.content.component;
 
 import io.github.noeppi_noeppi.libx.config.gui.ConfigEditor;
 import io.github.noeppi_noeppi.libx.config.gui.ConfigScreenContent;
+import io.github.noeppi_noeppi.libx.config.gui.EditorOps;
 import io.github.noeppi_noeppi.libx.config.gui.WidgetProperties;
 import io.github.noeppi_noeppi.libx.impl.config.gui.EditorHelper;
 import io.github.noeppi_noeppi.libx.impl.config.gui.screen.content.ListContent;
@@ -253,6 +254,7 @@ public class ComponentContent implements ConfigScreenContent<Component> {
             public void onPress() {
                 super.onPress();
                 ComponentContent.this.hasColor = this.selected();
+                EditorOps.wrap(ComponentContent.this.colorWidget).enabled(ComponentContent.this.hasColor);
                 ComponentContent.this.update();
             }
         };
@@ -264,6 +266,7 @@ public class ComponentContent implements ConfigScreenContent<Component> {
             this.color = color;
             this.update();
         });
+        EditorOps.wrap(this.colorWidget).enabled(this.hasColor);
         consumer.accept(this.colorWidget);
         
         y += (ColorPicker.HEIGHT + 5);

--- a/src/main/java/io/github/noeppi_noeppi/libx/impl/libxcore/CoreWorldSeed.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/impl/libxcore/CoreWorldSeed.java
@@ -6,7 +6,7 @@ import net.minecraft.world.level.levelgen.WorldGenSettings;
 public class CoreWorldSeed {
 
     /**
-     * Patched into the private constructor of {@link WorldGenSettings}
+     * Patched into the main constructor of {@link WorldGenSettings}
      * before any {@code return} passing the {@code seed} parameter.
      */
     public static void setWorldSeed(long seed) {

--- a/src/main/java/io/github/noeppi_noeppi/libx/inventory/VanillaWrapper.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/inventory/VanillaWrapper.java
@@ -73,11 +73,6 @@ public class VanillaWrapper implements Container {
     }
 
     @Override
-    public int getMaxStackSize() {
-        return 64;
-    }
-
-    @Override
     public void setChanged() {
         if (this.changed != null) {
             this.changed.run();
@@ -90,24 +85,18 @@ public class VanillaWrapper implements Container {
     }
 
     @Override
-    public void startOpen(@Nonnull Player player) {
-
-    }
-
-    @Override
-    public void stopOpen(@Nonnull Player player) {
-
-    }
-
-    @Override
     public boolean canPlaceItem(int index, @Nonnull ItemStack stack) {
         return this.handler.isItemValid(index, stack);
     }
 
     @Override
     public void clearContent() {
-        for (int i = 0; i < this.handler.getSlots(); i++) {
-            this.handler.setStackInSlot(i, ItemStack.EMPTY);
+        if (this.handler instanceof IAdvancedItemHandlerModifiable adv) {
+            adv.clear();
+        } else {
+            for (int i = 0; i < this.handler.getSlots(); i++) {
+                this.handler.setStackInSlot(i, ItemStack.EMPTY);
+            }
         }
     }
 }

--- a/src/main/java/io/github/noeppi_noeppi/libx/render/RenderHelperFluid.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/render/RenderHelperFluid.java
@@ -26,8 +26,7 @@ public class RenderHelperFluid {
     }
 
     public static void renderFluid(PoseStack poseStack, MultiBufferSource buffer, int color, int x, int y, int width, int height) {
-        Fluid fluid = Fluids.WATER;
-        TextureAtlasSprite sprite = Minecraft.getInstance().getTextureAtlas(InventoryMenu.BLOCK_ATLAS).apply(fluid.getAttributes().getStillTexture());
+        TextureAtlasSprite sprite = Minecraft.getInstance().getTextureAtlas(InventoryMenu.BLOCK_ATLAS).apply(Fluids.WATER.getAttributes().getStillTexture());
         renderFluid(poseStack, buffer, sprite, color, x, y, width, height);
     }
 

--- a/src/main/java/io/github/noeppi_noeppi/libx/screen/Panel.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/screen/Panel.java
@@ -1,6 +1,7 @@
 package io.github.noeppi_noeppi.libx.screen;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import io.github.noeppi_noeppi.libx.config.gui.EditorOps;
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.Widget;
 import net.minecraft.client.gui.components.events.GuiEventListener;
@@ -18,7 +19,7 @@ import java.util.List;
  * widgets are positioned relative to this widget. You can add these widgets in
  * the constructor.
  */
-public abstract class Panel extends AbstractWidget {
+public abstract class Panel extends AbstractWidget implements EditorOps {
 
     protected final Screen screen;
     private final List<GuiEventListener> children = new ArrayList<>();
@@ -98,7 +99,7 @@ public abstract class Panel extends AbstractWidget {
 
     @Override
     public boolean mouseDragged(double mouseX, double mouseY, int button, double dragX, double dragY) {
-        return this.focused != null && this.screen.isDragging() && button == 0 && this.focused.mouseDragged(mouseX - this.x, mouseY - this.y, button, dragX, dragY);
+        return this.focused != null && this.screen.isDragging() && this.focused.mouseDragged(mouseX - this.x, mouseY - this.y, button, dragX - this.x, dragY - this.y);
     }
 
     @Override
@@ -119,5 +120,12 @@ public abstract class Panel extends AbstractWidget {
     @Override
     public void updateNarration(@Nonnull NarrationElementOutput output) {
         //
+    }
+
+    @Override
+    public void enabled(boolean enabled) {
+        for (Widget child : this.renderables) {
+            EditorOps.wrap(child).enabled(enabled);
+        }
     }
 }

--- a/src/main/resources/assets/libx/lang/de_de.json
+++ b/src/main/resources/assets/libx/lang/de_de.json
@@ -45,7 +45,7 @@
   "libx.config.gui.component.underlined": "Unterstrichen: %s",
   "libx.config.gui.component.strikethrough": "Durchgestrichen: %s",
   "libx.config.gui.component.obfuscated": "Verdeckt: %s",
-  "libx.config.gui.component.siblings": "Zusätsliche Elemente",
+  "libx.config.gui.component.siblings": "Zusätzliche Elemente",
   "libx.config.gui.component.arguments": "Argumente",
   "libx.config.gui.component.type_text": "Text",
   "libx.config.gui.component.type_translate": "Übersetzung",


### PR DESCRIPTION
A few small changes:

  * Made `Panel` implement editor ops and redirect the methods to its children. This makes sure `Pair` and `Triple` values can be properly disabled in config GUIs when used inside `Optional`.
  * `ColorPicker`  can now be disabled which will show the colors in grayscale. This is now also used by the config editor for `Component`s
  * Removed the warning message when `UnionPath` is used in dynamic datapacks as UnionPath is fixed in all forge versions for 1.18.2
  * Dynamic datapacks will now use the pack version specified by the mod that declares them if possible.
  * Removed some methods from `VanillaWrapper` that are available as default methods in `Container`. Also `VanillaWrapper` will now use `IAdvancedItemHandlerModifiable#clear` if available.