### PR TITLE
Basic setup

### DIFF
--- a/src/ap/java/io/github/noeppi_noeppi/libx/annotation/processor/modinit/ModInit.java
+++ b/src/ap/java/io/github/noeppi_noeppi/libx/annotation/processor/modinit/ModInit.java
@@ -79,7 +79,7 @@ public class ModInit  {
             JavaFileObject file = filer.createSourceFile(((PackageElement) this.modClass.getEnclosingElement()).getQualifiedName() + "." + this.modClass.getSimpleName() + "$", this.modClass);
             Writer writer = file.openWriter();
             writer.write("package " + ((PackageElement) this.modClass.getEnclosingElement()).getQualifiedName() + ";");
-            writer.write("@" + SuppressWarnings.class.getCanonicalName() + "({\"all\",\"unchecked\",\"rawtypes\"})");
+            writer.write("@" + SuppressWarnings.class.getCanonicalName() + "({\"all\",\"unchecked\",\"rawtypes\",\"deprecation\"})");
             writer.write("public class " + this.modClass.getSimpleName() + "${");
             writer.write("private static " + Classes.sourceName(Classes.MODX) + " mod=null;");
             if (!this.codecs.isEmpty()) {

--- a/src/main/java/io/github/noeppi_noeppi/libx/impl/registration/RegistrationDispatcher.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/impl/registration/RegistrationDispatcher.java
@@ -1,0 +1,104 @@
+package io.github.noeppi_noeppi.libx.impl.registration;
+
+import io.github.noeppi_noeppi.libx.mod.ModXRegistration;
+import io.github.noeppi_noeppi.libx.registration.Registerable;
+import io.github.noeppi_noeppi.libx.registration.RegistrationBuilder;
+import io.github.noeppi_noeppi.libx.registration.resolution.RegistryResolver;
+import io.github.noeppi_noeppi.libx.registration.resolution.ResolvedRegistry;
+import net.minecraft.core.Holder;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.registries.IForgeRegistry;
+import net.minecraftforge.registries.IForgeRegistryEntry;
+
+import java.util.*;
+import java.util.function.Supplier;
+
+public class RegistrationDispatcher {
+    
+    private final Object LOCK = new Object();
+    
+    private final String modid;
+    
+    private final List<RegistryResolver> resolvers;
+    private final Map<ResourceKey<? extends Registry<?>>, Optional<ResolvedRegistry<?>>> resolvedRegistries;
+    
+    private final Map<ResourceKey<? extends Registry<?>>, Map<ResourceKey<?>, Object>> forgeEntries;
+    private final Map<Registry<?>, Map<ResourceKey<?>, Object>> vanillaEntries;
+    
+    public RegistrationDispatcher(String modid, RegistrationBuilder.Result result) {
+        this.modid = modid;
+        this.resolvers = result.resolvers();
+        this.resolvedRegistries = new HashMap<>();
+        this.forgeEntries = new HashMap<>();
+        this.vanillaEntries = new HashMap<>();
+    }
+    
+    private <T> Optional<ResolvedRegistry<T>> registry(ResourceKey<? extends Registry<T>> key) {
+        synchronized (this.LOCK) {
+            //noinspection unchecked
+            return (Optional<ResolvedRegistry<T>>) (Optional<?>) this.resolvedRegistries.computeIfAbsent(key, k ->
+                    (Optional<ResolvedRegistry<?>>) (Optional<?>) this.resolvers.stream().flatMap(resolver -> resolver.resolve(key).stream()).findFirst()
+            );
+        }
+    }
+    
+    private <T> Supplier<Holder<T>> register(ResourceKey<? extends Registry<T>> registry, String id, T value) {
+        synchronized (this.LOCK) {
+            if (value instanceof Registerable registerable) {
+                // TODO additional elements
+            }
+            ResourceKey<T> resourceKey = ResourceKey.create(registry, new ResourceLocation(this.modid, id));
+            if (registry != ModXRegistration.ANY_REGISTRY) {
+                ResolvedRegistry<T> resolved = this.registry(registry).orElseThrow(() -> new NoSuchElementException("Failed to resolve registry " + registry));
+                if (resolved instanceof ResolvedRegistry.Forge<?>) {
+                    this.addEntry(this.forgeEntries, registry, resourceKey, value);
+                } else if (resolved instanceof ResolvedRegistry.Vanilla<T> vanilla) {
+                    this.addEntry(this.vanillaEntries, vanilla.registry(), resourceKey, value);
+                }
+                return () -> resolved.createHolder(resourceKey);
+            } else {
+                return () -> {
+                    throw new IllegalStateException("Can't create holders for the " + ModXRegistration.ANY_REGISTRY.location() + " registry");
+                };
+            }
+        }
+    }
+    
+    private <T> void addEntry(Map<T, Map<ResourceKey<?>, Object>> entries, T key, ResourceKey<?> resourceKey, Object element) {
+        synchronized (this.LOCK) {
+            entries.computeIfAbsent(key, k -> new HashMap<>()).put(resourceKey, element);
+        }
+    }
+    
+    public void registerForge(RegistryEvent.Register<? extends IForgeRegistryEntry<?>> event) {
+        ResourceKey<? extends Registry<?>> key = ResourceKey.createRegistryKey(event.getName());
+        Map<ResourceKey<?>, Object> map = this.forgeEntries.get(key);
+        if (map != null) {
+            for (Map.Entry<ResourceKey<?>, Object> entry : map.entrySet()) {
+                if (!(entry.getValue() instanceof IForgeRegistryEntry<?>)) {
+                    throw new IllegalStateException("Can't register object into forge registry that is not an instance of IForgeRegistryEntry: " + entry.getValue() + " (" + entry.getKey() + ")");
+                } else if (!event.getRegistry().getRegistrySuperType().isAssignableFrom(entry.getValue().getClass())) {
+                    throw new IllegalStateException("Can't register object into forge registry: Type mismatch: " + entry.getValue() + " (" + entry.getKey() + ") expected " + event.getRegistry().getRegistrySuperType() + ", got " + entry.getClass());
+                } else {
+                    ((IForgeRegistryEntry<?>) entry.getValue()).setRegistryName(entry.getKey().location());
+                    //noinspection unchecked,rawtypes
+                    ((IForgeRegistry) event.getRegistry()).register((IForgeRegistryEntry<?>) entry.getValue());
+                }
+            }
+        }
+    }
+    
+    public void registerVanilla() {
+        synchronized (this.LOCK) {
+            for (Map.Entry<Registry<?>, Map<ResourceKey<?>, Object>> registryEntry : this.vanillaEntries.entrySet()) {
+                for (Map.Entry<ResourceKey<?>, Object> elementEntry : registryEntry.getValue().entrySet()) {
+                    //noinspection unchecked
+                    Registry.register((Registry<Object>) registryEntry.getKey(), (ResourceKey<Object>) elementEntry.getKey(), elementEntry.getValue());
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/io/github/noeppi_noeppi/libx/impl/registration/old/BuiltinTransformers.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/impl/registration/old/BuiltinTransformers.java
@@ -1,4 +1,4 @@
-package io.github.noeppi_noeppi.libx.impl.registration;
+package io.github.noeppi_noeppi.libx.impl.registration.old;
 
 import io.github.noeppi_noeppi.libx.annotation.meta.RemoveIn;
 import io.github.noeppi_noeppi.libx.mod.registration.RegistryTransformer;

--- a/src/main/java/io/github/noeppi_noeppi/libx/impl/registration/resolution/ForgeRegistryResolver.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/impl/registration/resolution/ForgeRegistryResolver.java
@@ -1,0 +1,27 @@
+package io.github.noeppi_noeppi.libx.impl.registration.resolution;
+
+import io.github.noeppi_noeppi.libx.registration.resolution.RegistryResolver;
+import io.github.noeppi_noeppi.libx.registration.resolution.ResolvedRegistry;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
+import net.minecraftforge.registries.IForgeRegistry;
+import net.minecraftforge.registries.RegistryManager;
+
+import java.util.Optional;
+
+public class ForgeRegistryResolver implements RegistryResolver {
+
+    public static final ForgeRegistryResolver INSTANCE = new ForgeRegistryResolver();
+
+    private ForgeRegistryResolver() {
+
+    }
+    
+    @Override
+    public <T> Optional<ResolvedRegistry<T>> resolve(ResourceKey<? extends Registry<T>> key) {
+        IForgeRegistry<?> registry = RegistryManager.ACTIVE.getRegistry(key.location());
+        if (registry == null) return Optional.empty();
+        //noinspection unchecked
+        return Optional.of(new ResolvedRegistry.Forge<T>(ResourceKey.createRegistryKey(registry.getRegistryName()), (Class<T>) registry.getRegistrySuperType()));
+    }
+}

--- a/src/main/java/io/github/noeppi_noeppi/libx/impl/registration/resolution/VanillaRegistryResolver.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/impl/registration/resolution/VanillaRegistryResolver.java
@@ -1,0 +1,24 @@
+package io.github.noeppi_noeppi.libx.impl.registration.resolution;
+
+import io.github.noeppi_noeppi.libx.registration.resolution.RegistryResolver;
+import io.github.noeppi_noeppi.libx.registration.resolution.ResolvedRegistry;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
+
+import java.util.Optional;
+
+public class VanillaRegistryResolver implements RegistryResolver {
+
+    private final Registry<? extends Registry<?>> rootRegistry;
+
+    public VanillaRegistryResolver(Registry<? extends Registry<?>> rootRegistry) {
+        this.rootRegistry = rootRegistry;
+    }
+
+    @Override
+    public <T> Optional<ResolvedRegistry<T>> resolve(ResourceKey<? extends Registry<T>> key) {
+        if (this.rootRegistry.key().location().equals(key.location())) return Optional.empty();
+        //noinspection unchecked
+        return (Optional<ResolvedRegistry<T>>) (Optional<?>) ((Registry<Object>) (Registry<?>) this.rootRegistry).getOptional((ResourceKey<Object>) (ResourceKey<?>) key);
+    }
+}

--- a/src/main/java/io/github/noeppi_noeppi/libx/mod/ModX.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/mod/ModX.java
@@ -3,7 +3,6 @@ package io.github.noeppi_noeppi.libx.mod;
 import io.github.noeppi_noeppi.libx.annotation.meta.RemoveIn;
 import io.github.noeppi_noeppi.libx.impl.ModInternal;
 import io.github.noeppi_noeppi.libx.impl.config.ModMappers;
-import io.github.noeppi_noeppi.libx.mod.registration.ModXRegistration;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraftforge.fml.ModLoadingContext;
@@ -77,7 +76,7 @@ public abstract class ModX {
         // As the generated code registers registration handlers this will produce a null pointer exception
         // as the list of handlers will be null. So for instances of ModXRegistration we don't call it here
         // but in the constructor of ModXRegistration
-        if (!(this instanceof ModXRegistration)) {
+        if (!(this instanceof ModXRegistration) && !(this instanceof io.github.noeppi_noeppi.libx.mod.registration.ModXRegistration)) {
             ModInternal.get(this).callGeneratedCode();
         }
     }

--- a/src/main/java/io/github/noeppi_noeppi/libx/mod/ModXRegistration.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/mod/ModXRegistration.java
@@ -4,6 +4,7 @@ import io.github.noeppi_noeppi.libx.impl.ModInternal;
 import io.github.noeppi_noeppi.libx.impl.registration.RegistrationDispatcher;
 import io.github.noeppi_noeppi.libx.registration.Registerable;
 import io.github.noeppi_noeppi.libx.registration.RegistrationBuilder;
+import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
@@ -45,10 +46,25 @@ public abstract class ModXRegistration extends ModX {
         }
         
         ModInternal.get(this).addSetupTask(this.dispatcher::registerVanilla, true);
+
+        FMLJavaModLoadingContext.get().getModEventBus().addListener(this.dispatcher::registerCommon);
+        FMLJavaModLoadingContext.get().getModEventBus().addListener(this.dispatcher::registerClient);
         
         // Call the generated code here as well
         ModInternal.get(this).callGeneratedCode();
     }
 
     protected abstract void initRegistration(RegistrationBuilder builder);
+    
+    public final <T> void register(String id, Registerable value) {
+        this.register(ANY_REGISTRY, id, value);
+    }
+    
+    public final <T> void register(ResourceKey<? extends Registry<T>> registry, String id, T value) {
+        this.dispatcher.register(registry, id, value);
+    }
+    
+    public final <T> Holder<T> createHolder(ResourceKey<? extends Registry<T>> registry, String id, T value) {
+        return this.dispatcher.register(registry, id, value).get();
+    }
 }

--- a/src/main/java/io/github/noeppi_noeppi/libx/mod/ModXRegistration.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/mod/ModXRegistration.java
@@ -1,0 +1,54 @@
+package io.github.noeppi_noeppi.libx.mod;
+
+import io.github.noeppi_noeppi.libx.impl.ModInternal;
+import io.github.noeppi_noeppi.libx.impl.registration.RegistrationDispatcher;
+import io.github.noeppi_noeppi.libx.registration.Registerable;
+import io.github.noeppi_noeppi.libx.registration.RegistrationBuilder;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.EventBus;
+import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.Method;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+public abstract class ModXRegistration extends ModX {
+    
+    // Don't use LibX#resource because of classloading order.
+    public static final ResourceKey<? extends Registry<Registerable>> ANY_REGISTRY = ResourceKey.createRegistryKey(new ResourceLocation("libx", "any"));
+
+    private final RegistrationDispatcher dispatcher;
+    
+    protected ModXRegistration() {
+        this(null);
+    }
+
+    protected ModXRegistration(@Nullable CreativeModeTab tab) {
+        super(tab);
+
+        RegistrationBuilder builder = new RegistrationBuilder();
+        this.initRegistration(builder);
+        this.dispatcher = new RegistrationDispatcher(this.modid, builder.build());
+        
+        try {
+            Method method = EventBus.class.getDeclaredMethod("addListener", EventPriority.class, Predicate.class, Class.class, Consumer.class);
+            method.setAccessible(true);
+            method.invoke(FMLJavaModLoadingContext.get().getModEventBus(), EventPriority.NORMAL, (Predicate<Object>) obj -> true, RegistryEvent.Register.class, (Consumer<RegistryEvent.Register<?>>) this.dispatcher::registerForge);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Could not add generic listener to listen to all registry events for mod " + this.modid + ".", e);
+        }
+        
+        ModInternal.get(this).addSetupTask(this.dispatcher::registerVanilla, true);
+        
+        // Call the generated code here as well
+        ModInternal.get(this).callGeneratedCode();
+    }
+
+    protected abstract void initRegistration(RegistrationBuilder builder);
+}

--- a/src/main/java/io/github/noeppi_noeppi/libx/mod/registration/RegistrationBuilder.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/mod/registration/RegistrationBuilder.java
@@ -2,7 +2,7 @@ package io.github.noeppi_noeppi.libx.mod.registration;
 
 import com.google.common.collect.ImmutableList;
 import io.github.noeppi_noeppi.libx.annotation.meta.RemoveIn;
-import io.github.noeppi_noeppi.libx.impl.registration.BuiltinTransformers;
+import io.github.noeppi_noeppi.libx.impl.registration.old.BuiltinTransformers;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/io/github/noeppi_noeppi/libx/network/NetworkX.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/network/NetworkX.java
@@ -36,7 +36,7 @@ public abstract class NetworkX {
                 remote -> this.protocol.client().predicate.test(this.protocol.version(), remote),
                 remote -> this.protocol.server().predicate.test(this.protocol.version(), remote)
         );
-        ModInternal.get(mod).addSetupTask(this::registerPackets);
+        ModInternal.get(mod).addSetupTask(this::registerPackets, false);
     }
 
     /**

--- a/src/main/java/io/github/noeppi_noeppi/libx/registration/Registerable.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/registration/Registerable.java
@@ -1,0 +1,4 @@
+package io.github.noeppi_noeppi.libx.registration;
+
+public interface Registerable {
+}

--- a/src/main/java/io/github/noeppi_noeppi/libx/registration/Registerable.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/registration/Registerable.java
@@ -1,4 +1,43 @@
 package io.github.noeppi_noeppi.libx.registration;
 
+import io.github.noeppi_noeppi.libx.mod.ModXRegistration;
+import net.minecraft.core.Holder;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+
+import java.util.function.Consumer;
+
 public interface Registerable {
+    
+    default void registerCommon(Consumer<Runnable> defer) {
+        
+    }
+    
+    @OnlyIn(Dist.CLIENT)
+    default void registerClient(Consumer<Runnable> defer) {
+        
+    }
+    
+    default void buildAdditionalRegisters(EntryCollector builder) {
+        
+    } 
+    
+    interface EntryCollector {
+        
+        <T> void register(ResourceKey<? extends Registry<T>> registry, T value);
+        <T> void registerNamed(ResourceKey<? extends Registry<T>> registry, String name, T value);
+        
+        <T> Holder<T> createHolder(ResourceKey<? extends Registry<T>> registry, T value);
+        <T> Holder<T> createNamedHolder(ResourceKey<? extends Registry<T>> registry, String name, T value);
+        
+        default void register(Registerable value) {
+            this.register(ModXRegistration.ANY_REGISTRY, value);
+        }
+        
+        default void registerNamed(String name, Registerable value) {
+            this.registerNamed(ModXRegistration.ANY_REGISTRY, name, value);
+        }
+    }
 }

--- a/src/main/java/io/github/noeppi_noeppi/libx/registration/RegistrationBuilder.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/registration/RegistrationBuilder.java
@@ -1,0 +1,54 @@
+package io.github.noeppi_noeppi.libx.registration;
+
+import io.github.noeppi_noeppi.libx.impl.registration.resolution.ForgeRegistryResolver;
+import io.github.noeppi_noeppi.libx.impl.registration.resolution.VanillaRegistryResolver;
+import io.github.noeppi_noeppi.libx.registration.resolution.RegistryResolver;
+import io.github.noeppi_noeppi.libx.registration.resolution.ResolvedRegistry;
+import net.minecraft.core.Registry;
+import net.minecraft.data.BuiltinRegistries;
+import net.minecraft.resources.ResourceKey;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class RegistrationBuilder {
+    
+    private final List<RegistryResolver> resolvers;
+    
+    public RegistrationBuilder() {
+        this.resolvers = new ArrayList<>();
+    }
+    
+    public RegistrationBuilder resolve(RegistryResolver resolver) {
+        this.resolvers.add(resolver);
+        return this;
+    }
+    
+    public <T> RegistrationBuilder resolve(ResourceKey<? extends Registry<T>> id, ResolvedRegistry<T> registry) {
+        return this.resolve(new RegistryResolver() {
+            
+            @Override
+            public <A> Optional<ResolvedRegistry<A>> resolve(ResourceKey<? extends Registry<A>> key) {
+                //noinspection unchecked
+                return id.equals(key) ? Optional.of((ResolvedRegistry<A>) registry) : Optional.empty();
+            }
+        });
+    }
+    
+    public <T> RegistrationBuilder resolve(ResourceKey<? extends Registry<T>> id, Registry<T> registry) {
+        return this.resolve(id, new ResolvedRegistry.Vanilla<>(registry));
+    }
+    
+    public Result build() {
+        List<RegistryResolver> resolvers = Stream.concat(this.resolvers.stream(), Stream.of(
+                ForgeRegistryResolver.INSTANCE,
+                new VanillaRegistryResolver(Registry.REGISTRY),
+                new VanillaRegistryResolver(BuiltinRegistries.REGISTRY)
+        )).toList();
+        return new Result(resolvers);
+    }
+    
+    public static record Result(List<RegistryResolver> resolvers) {}
+}

--- a/src/main/java/io/github/noeppi_noeppi/libx/registration/resolution/RegistryResolver.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/registration/resolution/RegistryResolver.java
@@ -1,0 +1,11 @@
+package io.github.noeppi_noeppi.libx.registration.resolution;
+
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
+
+import java.util.Optional;
+
+public interface RegistryResolver {
+    
+    <T> Optional<ResolvedRegistry<T>> resolve(ResourceKey<? extends Registry<T>> key);
+}

--- a/src/main/java/io/github/noeppi_noeppi/libx/registration/resolution/ResolvedRegistry.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/registration/resolution/ResolvedRegistry.java
@@ -1,0 +1,41 @@
+package io.github.noeppi_noeppi.libx.registration.resolution;
+
+import net.minecraft.core.Holder;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
+import net.minecraftforge.registries.IForgeRegistryEntry;
+
+import javax.annotation.Nullable;
+
+public sealed interface ResolvedRegistry<T> permits ResolvedRegistry.Forge, ResolvedRegistry.Vanilla {
+    
+    ResourceKey<? extends Registry<T>> registryKey();
+    
+    @Nullable
+    default Class<T> superType() {
+        return null;
+    }
+
+    default Holder<T> createHolder(ResourceKey<T> key) {
+        throw new IllegalStateException("The registry " + this.getClass().getSimpleName() + "[" + this.registryKey() + "] can't be used to create holders");
+    }
+    
+    record Forge<T>(ResourceKey<? extends Registry<T>> registryKey, Class<T> superType) implements ResolvedRegistry<T> {}
+    
+    record Vanilla<T>(Registry<T> registry) implements ResolvedRegistry<T> {
+        
+        @Override
+        public ResourceKey<? extends Registry<T>> registryKey() {
+            return this.registry().key();
+        }
+
+        @Override
+        public Holder<T> createHolder(ResourceKey<T> key) {
+            try {
+                return this.registry().getOrCreateHolder(key);
+            } catch(IllegalStateException e) {
+                return ResolvedRegistry.super.createHolder(key);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add a new implementation for `ModXRegistration`, add `RegistrationBuilder`, resolution of registries (forge and vanilla) and an `RegistryDispatcher` to register stuff into the registries. Also add a ways to retrieve holders when registering (which might not work as intended, needs testing later.)

This should give a basic setup, so other parts can build on it.