### PR TITLE
fix wrong experience values for blasting, and cooking

### DIFF
--- a/src/main/java/io/github/noeppi_noeppi/libx/data/provider/recipe/SmeltingExtension.java
+++ b/src/main/java/io/github/noeppi_noeppi/libx/data/provider/recipe/SmeltingExtension.java
@@ -22,8 +22,8 @@ public interface SmeltingExtension extends RecipeExtension {
 
     /**
      * Adds a smelting recipe that can be performed in a regular furnace and a blast furnace.
-     * {@code time} and {@code exp} should be the values for the normal furnace. They'll be
-     * adjusted for the blast furnace automatically.
+     * {@code time} should be the value for the normal furnace. It'll be adjusted for the blast
+     * furnace automatically.
      */
     default void blasting(ItemLike in, ItemLike out, float exp, int time) {
         this.blasting(this.provider().loc(out), in, out, exp, time);
@@ -31,8 +31,8 @@ public interface SmeltingExtension extends RecipeExtension {
 
     /**
      * Adds a smelting recipe that can be performed in a regular furnace and a smoker.
-     * {@code time} and {@code exp} should be the values for the normal furnace. They'll be
-     * adjusted for the smoker automatically.
+     * {@code time} should be the value for the normal furnace. It'll be adjusted for
+     * the smoker automatically.
      */
     default void cooking(ItemLike in, ItemLike out, float exp, int time) {
         this.cooking(this.provider().loc(out), in, out, exp, time);
@@ -40,8 +40,8 @@ public interface SmeltingExtension extends RecipeExtension {
 
     /**
      * Adds a smelting recipe that can be performed in a regular furnace, a smoker anda campfire.
-     * {@code time} and {@code exp} should be the values for the normal furnace. They'll be
-     * adjusted for the smoker and the campfire automatically.
+     * {@code time} should be the value for the normal furnace. It'll be adjusted for the smoker
+     * and the campfire automatically.
      */
     default void campfire(ItemLike in, ItemLike out, float exp, int time) {
         this.campfire(this.provider().loc(out), in, out, exp, time);
@@ -56,8 +56,8 @@ public interface SmeltingExtension extends RecipeExtension {
 
     /**
      * Adds a smelting recipe that can be performed in a regular furnace and a blast furnace.
-     * {@code time} and {@code exp} should be the values for the normal furnace. They'll be
-     * adjusted for the blast furnace automatically.
+     * {@code time} should be the value for the normal furnace. It'll be adjusted for the blast
+     * furnace automatically.
      */
     default void blasting(TagKey<Item> in, ItemLike out, float exp, int time) {
         this.blasting(this.provider().loc(out), in, out, exp, time);
@@ -65,8 +65,8 @@ public interface SmeltingExtension extends RecipeExtension {
 
     /**
      * Adds a smelting recipe that can be performed in a regular furnace and a smoker.
-     * {@code time} and {@code exp} should be the values for the normal furnace. They'll be
-     * adjusted for the smoker automatically.
+     * {@code time} should be the value for the normal furnace. They'll be adjusted for
+     * the smoker automatically.
      */
     default void cooking(TagKey<Item> in, ItemLike out, float exp, int time) {
         this.cooking(this.provider().loc(out), in, out, exp, time);
@@ -74,8 +74,8 @@ public interface SmeltingExtension extends RecipeExtension {
 
     /**
      * Adds a smelting recipe that can be performed in a regular furnace, a smoker anda campfire.
-     * {@code time} and {@code exp} should be the values for the normal furnace. They'll be
-     * adjusted for the smoker and the campfire automatically.
+     * {@code time} should be the value for the normal furnace. It'll be adjusted for the smoker
+     * and the campfire automatically.
      */
     default void campfire(TagKey<Item> in, ItemLike out, float exp, int time) {
         this.campfire(this.provider().loc(out), in, out, exp, time);
@@ -92,36 +92,36 @@ public interface SmeltingExtension extends RecipeExtension {
 
     /**
      * Adds a smelting recipe that can be performed in a regular furnace and a blast furnace.
-     * {@code time} and {@code exp} should be the values for the normal furnace. They'll be
-     * adjusted for the blast furnace automatically.
+     * {@code time} should be the value for the normal furnace. It'll be adjusted for the blast
+     * furnace automatically.
      */
     default void blasting(ResourceLocation outputId, ItemLike in, ItemLike out, float exp, int time) {
         this.smelting(outputId, in, out, exp, time);
-        SimpleCookingRecipeBuilder.blasting(Ingredient.of(in), out, exp / 2, time / 2)
+        SimpleCookingRecipeBuilder.blasting(Ingredient.of(in), out, exp, time / 2)
                 .unlockedBy("has_item", this.criterion(in))
                 .save(this.consumer(), new ResourceLocation(outputId.getNamespace(), "blasting/" + outputId.getPath()));
     }
 
     /**
      * Adds a smelting recipe that can be performed in a regular furnace and a smoker.
-     * {@code time} and {@code exp} should be the values for the normal furnace. They'll be
-     * adjusted for the smoker automatically.
+     * {@code time} should be the value for the normal furnace. It'll be adjusted for
+     * the smoker automatically.
      */
     default void cooking(ResourceLocation outputId, ItemLike in, ItemLike out, float exp, int time) {
         this.smelting(outputId, in, out, exp, time);
-        SimpleCookingRecipeBuilder.cooking(Ingredient.of(in), out, exp / 2, time / 2, RecipeSerializer.SMOKING_RECIPE)
+        SimpleCookingRecipeBuilder.cooking(Ingredient.of(in), out, exp, time / 2, RecipeSerializer.SMOKING_RECIPE)
                 .unlockedBy("has_item", this.criterion(in))
                 .save(this.consumer(), new ResourceLocation(outputId.getNamespace(), "cooking/" + outputId.getPath()));
     }
 
     /**
      * Adds a smelting recipe that can be performed in a regular furnace, a smoker anda campfire.
-     * {@code time} and {@code exp} should be the values for the normal furnace. They'll be
-     * adjusted for the smoker and the campfire automatically.
+     * {@code time} should be the value for the normal furnace. It'll be adjusted for the smoker
+     * and the campfire automatically.
      */
     default void campfire(ResourceLocation outputId, ItemLike in, ItemLike out, float exp, int time) {
         this.cooking(outputId, in, out, exp, time);
-        SimpleCookingRecipeBuilder.cooking(Ingredient.of(in), out, exp / 2, time * 3, RecipeSerializer.CAMPFIRE_COOKING_RECIPE)
+        SimpleCookingRecipeBuilder.cooking(Ingredient.of(in), out, exp, time * 3, RecipeSerializer.CAMPFIRE_COOKING_RECIPE)
                 .unlockedBy("has_item", this.criterion(in))
                 .save(this.consumer(), new ResourceLocation(outputId.getNamespace(), "campfire/" + outputId.getPath()));
     }
@@ -137,36 +137,36 @@ public interface SmeltingExtension extends RecipeExtension {
 
     /**
      * Adds a smelting recipe that can be performed in a regular furnace and a blast furnace.
-     * {@code time} and {@code exp} should be the values for the normal furnace. They'll be
-     * adjusted for the blast furnace automatically.
+     * {@code time} should be the value for the normal furnace. It'll be adjusted for the blast
+     * furnace automatically.
      */
     default void blasting(ResourceLocation outputId, TagKey<Item> in, ItemLike out, float exp, int time) {
         this.smelting(outputId, in, out, exp, time);
-        SimpleCookingRecipeBuilder.blasting(Ingredient.of(in), out, exp / 2, time / 2)
+        SimpleCookingRecipeBuilder.blasting(Ingredient.of(in), out, exp, time / 2)
                 .unlockedBy("has_item", this.criterion(in))
                 .save(this.consumer(), new ResourceLocation(outputId.getNamespace(), "blasting/" + outputId.getPath()));
     }
 
     /**
      * Adds a smelting recipe that can be performed in a regular furnace and a smoker.
-     * {@code time} and {@code exp} should be the values for the normal furnace. They'll be
-     * adjusted for the smoker automatically.
+     * {@code time} should be the value for the normal furnace. It'll be adjusted for
+     * the smoker automatically.
      */
     default void cooking(ResourceLocation outputId, TagKey<Item> in, ItemLike out, float exp, int time) {
         this.smelting(outputId, in, out, exp, time);
-        SimpleCookingRecipeBuilder.cooking(Ingredient.of(in), out, exp / 2, time / 2, RecipeSerializer.SMOKING_RECIPE)
+        SimpleCookingRecipeBuilder.cooking(Ingredient.of(in), out, exp, time / 2, RecipeSerializer.SMOKING_RECIPE)
                 .unlockedBy("has_item", this.criterion(in))
                 .save(this.consumer(), new ResourceLocation(outputId.getNamespace(), "cooking/" + outputId.getPath()));
     }
 
     /**
      * Adds a smelting recipe that can be performed in a regular furnace, a smoker anda campfire.
-     * {@code time} and {@code exp} should be the values for the normal furnace. They'll be
-     * adjusted for the smoker and the campfire automatically.
+     * {@code time} should be the value for the normal furnace. It'll be adjusted for the smoker
+     * and the campfire automatically.
      */
     default void campfire(ResourceLocation outputId, TagKey<Item> in, ItemLike out, float exp, int time) {
         this.cooking(outputId, in, out, exp, time);
-        SimpleCookingRecipeBuilder.cooking(Ingredient.of(in), out, exp / 2, time * 3, RecipeSerializer.CAMPFIRE_COOKING_RECIPE)
+        SimpleCookingRecipeBuilder.cooking(Ingredient.of(in), out, exp, time * 3, RecipeSerializer.CAMPFIRE_COOKING_RECIPE)
                 .unlockedBy("has_item", this.criterion(in))
                 .save(this.consumer(), new ResourceLocation(outputId.getNamespace(), "campfire/" + outputId.getPath()));
     }


### PR DESCRIPTION
This fixes that the experience value will be divided by 2 when cooking, and blasting. This is based on the vanilla values, which also use the same experience in each smelting type.