### PR TITLE
Patchouli datagen

### DIFF
--- a/src/ap/java/org/moddingx/libx/annotation/processor/meta/ExperimentalProcessor.java
+++ b/src/ap/java/org/moddingx/libx/annotation/processor/meta/ExperimentalProcessor.java
@@ -24,7 +24,7 @@ public class ExperimentalProcessor extends Processor {
         for (Element element : roundEnv.getElementsAnnotatedWith(Experimental.class)) {
             Boolean release = ExternalProperties.release(this);
             if (release != null && release) {
-                this.messager().printMessage(Diagnostic.Kind.ERROR, "Releases may not contain experimental members.", element);
+                this.messager().printMessage(Diagnostic.Kind.WARNING, "Releases should not contain experimental members.", element);
             }
         }
     }

--- a/src/main/java/org/moddingx/libx/datagen/provider/patchouli/BookProperties.java
+++ b/src/main/java/org/moddingx/libx/datagen/provider/patchouli/BookProperties.java
@@ -1,0 +1,27 @@
+package org.moddingx.libx.datagen.provider.patchouli;
+
+import net.minecraft.server.packs.PackType;
+
+/**
+ * Basic properties for a patchouli book.
+ * 
+ * @param bookName The name of the book.
+ * @param packTarget The target, where the book should be generated. If {@code use_resource_pack} is set in {@code book.json},
+ *                   this should be {@link PackType#CLIENT_RESOURCES}, if not {@link PackType#SERVER_DATA}.
+ * @param translate Whether the book is translatable. If this is {@code true}, a language ile for {@code en_us} is generated
+ *                  in a different namespace ({@code modid_bookname}), so it does not clash with the main language file when the
+ *                  jar is built.
+ */
+public record BookProperties(String bookName, PackType packTarget, boolean translate) {
+
+    public BookProperties(String name) {
+        this(name, PackType.SERVER_DATA, false);
+    }
+    
+    public BookProperties(String name, PackType packTarget) {
+        this(name, packTarget, false);
+    }
+    public BookProperties(String name, boolean translate) {
+        this(name, PackType.SERVER_DATA, translate);
+    }
+}

--- a/src/main/java/org/moddingx/libx/datagen/provider/patchouli/BookProperties.java
+++ b/src/main/java/org/moddingx/libx/datagen/provider/patchouli/BookProperties.java
@@ -1,6 +1,7 @@
 package org.moddingx.libx.datagen.provider.patchouli;
 
 import net.minecraft.server.packs.PackType;
+import org.moddingx.libx.annotation.meta.Experimental;
 
 /**
  * Basic properties for a patchouli book.
@@ -12,6 +13,7 @@ import net.minecraft.server.packs.PackType;
  *                  in a different namespace ({@code modid_bookname}), so it does not clash with the main language file when the
  *                  jar is built.
  */
+@Experimental
 public record BookProperties(String bookName, PackType packTarget, boolean translate) {
 
     public BookProperties(String name) {

--- a/src/main/java/org/moddingx/libx/datagen/provider/patchouli/CategoryBuilder.java
+++ b/src/main/java/org/moddingx/libx/datagen/provider/patchouli/CategoryBuilder.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonObject;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ItemLike;
+import org.moddingx.libx.annotation.meta.Experimental;
 import org.moddingx.libx.datagen.provider.patchouli.page.PageJson;
 
 import java.util.ArrayList;
@@ -14,6 +15,7 @@ import java.util.function.Consumer;
 /**
  * Builder for a patchouli book category.
  */
+@Experimental
 public class CategoryBuilder {
 
     public final ResourceLocation id;

--- a/src/main/java/org/moddingx/libx/datagen/provider/patchouli/CategoryBuilder.java
+++ b/src/main/java/org/moddingx/libx/datagen/provider/patchouli/CategoryBuilder.java
@@ -1,0 +1,96 @@
+package org.moddingx.libx.datagen.provider.patchouli;
+
+import com.google.gson.JsonObject;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ItemLike;
+import org.moddingx.libx.datagen.provider.patchouli.page.PageJson;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+
+/**
+ * Builder for a patchouli book category.
+ */
+public class CategoryBuilder {
+
+    public final ResourceLocation id;
+    private String name;
+    private String description;
+    private ItemStack icon;
+    
+    private int sort;
+    private final List<Consumer<JsonObject>> postProcessors;
+
+    public CategoryBuilder(ResourceLocation id) {
+        this.id = id;
+        this.sort = -1;
+        this.postProcessors = new ArrayList<>();
+    }
+
+    /**
+     * Sets the category name. This is required.
+     */
+    public CategoryBuilder name(String name) {
+        this.name = name;
+        return this;
+    }
+    
+    /**
+     * Sets the category description. This is required.
+     */
+    public CategoryBuilder description(String description) {
+        this.description = description;
+        return this;
+    }
+    
+    /**
+     * Sets the category icon. This is required.
+     */
+    public CategoryBuilder icon(ItemLike icon) {
+        return this.icon(new ItemStack(icon));
+    }
+    
+    /**
+     * Sets the category icon. This is required.
+     */
+    public CategoryBuilder icon(ItemStack icon) {
+        this.icon = icon.copy();
+        return this;
+    }
+
+    /**
+     * Sets a sort num directly. If this is not called, categories will be sorted in order they are created.
+     */
+    public CategoryBuilder sort(int sort) {
+        this.sort = sort;
+        return this;
+    }
+
+    /**
+     * Adds a {@link Consumer} that can modify the final json data after it is built.
+     */
+    public CategoryBuilder postProcess(Consumer<JsonObject> postProcessor) {
+        this.postProcessors.add(postProcessor);
+        return this;
+    }
+    
+    JsonObject build(BiFunction<String, List<String>, String> translations, int num) {
+        if (this.name == null) throw new IllegalStateException("Category name not set: " + this.id);
+        if (this.description == null) throw new IllegalStateException("Category description not set: " + this.id);
+        if (this.icon == null) throw new IllegalStateException("Category icon not set: " + this.id);
+        JsonObject json = new JsonObject();
+        json.addProperty("name", translations.apply(this.name, List.of("category", this.id.getNamespace(), this.id.getPath(), "name")));
+        json.addProperty("description", translations.apply(this.description, List.of("category", this.id.getNamespace(), this.id.getPath(), "description")));
+        json.add("icon", PageJson.stack(this.icon));
+        json.addProperty("sortnum", this.sort < 0 ? num : this.sort);
+        
+        for (Consumer<JsonObject> postProcessor : this.postProcessors) {
+            postProcessor.accept(json);
+        }
+        
+        return json;
+    }
+}

--- a/src/main/java/org/moddingx/libx/datagen/provider/patchouli/EntryBuilder.java
+++ b/src/main/java/org/moddingx/libx/datagen/provider/patchouli/EntryBuilder.java
@@ -8,6 +8,7 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ItemLike;
 import net.minecraftforge.common.data.ExistingFileHelper;
+import org.moddingx.libx.annotation.meta.Experimental;
 import org.moddingx.libx.datagen.provider.patchouli.content.CaptionContent;
 import org.moddingx.libx.datagen.provider.patchouli.content.TextContent;
 import org.moddingx.libx.datagen.provider.patchouli.page.Content;
@@ -24,6 +25,7 @@ import java.util.function.Consumer;
 /**
  * Builder for a patchouli book entry.
  */
+@Experimental
 public class EntryBuilder {
     
     public final String id;

--- a/src/main/java/org/moddingx/libx/datagen/provider/patchouli/EntryBuilder.java
+++ b/src/main/java/org/moddingx/libx/datagen/provider/patchouli/EntryBuilder.java
@@ -1,0 +1,323 @@
+package org.moddingx.libx.datagen.provider.patchouli;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.PackType;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ItemLike;
+import net.minecraftforge.common.data.ExistingFileHelper;
+import org.moddingx.libx.datagen.provider.patchouli.content.CaptionContent;
+import org.moddingx.libx.datagen.provider.patchouli.content.TextContent;
+import org.moddingx.libx.datagen.provider.patchouli.page.Content;
+import org.moddingx.libx.datagen.provider.patchouli.page.PageBuilder;
+import org.moddingx.libx.datagen.provider.patchouli.page.PageJson;
+import org.moddingx.libx.impl.datagen.patchouli.content.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+
+/**
+ * Builder for a patchouli book entry.
+ */
+public class EntryBuilder {
+    
+    public final String id;
+    public final ResourceLocation category;
+    private String name;
+    private ItemStack icon;
+    private ResourceLocation advancement;
+    private Content content;
+    private final List<Consumer<JsonObject>> postProcessors;
+
+    public EntryBuilder(String id, ResourceLocation category) {
+        this.id = id;
+        this.category = category;
+        this.name = null;
+        this.icon = null;
+        this.advancement = null;
+        this.content = Content.EMPTY;
+        this.postProcessors = new ArrayList<>();
+    }
+
+    /**
+     * Sets the entry name. This is required.
+     */
+    public EntryBuilder name(String name) {
+        this.name = name;
+        return this;
+    }
+    
+    /**
+     * Sets the entry icon. This is required.
+     */
+    public EntryBuilder icon(ItemLike icon) {
+        return this.icon(new ItemStack(icon));
+    }
+    
+    /**
+     * Sets the entry icon. This is required.
+     */
+    public EntryBuilder icon(ItemStack icon) {
+        this.icon = icon.copy();
+        return this;
+    }
+
+    /**
+     * Sets an advancement needed to unlock the entry. The namespace is set to the namespace of the category, this
+     * entry belongs to.
+     */
+    public EntryBuilder advancement(String path) {
+        return this.advancement(this.category.getNamespace(), path);
+    }
+
+    /**
+     * Sets an advancement needed to unlock the entry.
+     */
+    public EntryBuilder advancement(String namespace, String path) {
+        return this.advancement(new ResourceLocation(namespace, path));
+    }
+
+    /**
+     * Sets an advancement needed to unlock the entry.
+     */
+    public EntryBuilder advancement(ResourceLocation advancement) {
+        this.advancement = advancement;
+        return this;
+    }
+
+    /**
+     * Adds some text content to this entry.
+     */
+    public EntryBuilder text(String text) {
+        return this.add(new TextContent(text, false));
+    }
+
+    /**
+     * Adds some caption text content to the entry. Caption text behaves as regular text except when added right
+     * after a {@link CaptionContent} in which case the caption text will merge onto the previous content.
+     */
+    public EntryBuilder caption(String text) {
+        return this.add(new TextContent(text, true));
+    }
+    
+    /**
+     * Causes a page flip. That means no text after a flip will be put on a page that started before the flip.
+     */
+    public EntryBuilder flip() {
+        return this.add(new FlipContent(null));
+    }
+
+    /**
+     * Causes a page flip. That means no text after a flip will be put on a page that started before the flip.
+     * Also adds an anchor to the next page that is built, that can then be referenced by links inside the book.
+     */
+    public EntryBuilder flip(String anchor) {
+        return this.add(new FlipContent(anchor));
+    }
+
+    /**
+     * Adds some images to the entry. The image namespaces are set to the namespace of the category, this entry belongs to.
+     */
+    public EntryBuilder image(String title, String... images) {
+        return this.image(title, Arrays.stream(images).map(s -> new ResourceLocation(this.category.getNamespace(), s)).toArray(ResourceLocation[]::new));
+    }
+    
+    /**
+     * Adds some images to the entry.
+     */
+    public EntryBuilder image(String title, ResourceLocation... images) {
+        return this.add(new ImageContent(title, List.of(images), null));
+    }
+
+    /**
+     * Adds a crafting recipe to the entry. If the previous content is a crafting recipe as well, they'll merge together
+     * and form a double recipe page.
+     */
+    public EntryBuilder crafting(String path) {
+        return this.crafting(this.category.getNamespace(), path);
+    }
+    
+    /**
+     * Adds a crafting recipe to the entry. If the previous content is a crafting recipe as well, they'll merge together
+     * and form a double recipe page.
+     */
+    public EntryBuilder crafting(String namespace, String path) {
+        return this.crafting(new ResourceLocation(namespace, path));
+    }
+    
+    /**
+     * Adds a crafting recipe to the entry. If the previous content is a crafting recipe as well, they'll merge together
+     * and form a double recipe page.
+     */
+    public EntryBuilder crafting(ResourceLocation id) {
+        return this.add(new DoubleRecipePage("patchouli:crafting", 8, id));
+    }
+
+    /**
+     * Adds a smelting recipe to the entry. If the previous content is a smelting recipe as well, they'll merge together
+     * and form a double recipe page.
+     */
+    public EntryBuilder smelting(String path) {
+        return this.smelting(this.category.getNamespace(), path);
+    }
+
+    /**
+     * Adds a smelting recipe to the entry. If the previous content is a smelting recipe as well, they'll merge together
+     * and form a double recipe page.
+     */
+    public EntryBuilder smelting(String namespace, String path) {
+        return this.smelting(new ResourceLocation(namespace, path));
+    }
+
+    /**
+     * Adds a smelting recipe to the entry. If the previous content is a smelting recipe as well, they'll merge together
+     * and form a double recipe page.
+     */
+    public EntryBuilder smelting(ResourceLocation id) {
+        return this.add(new DoubleRecipePage("patchouli:smelting", 4, id));
+    }
+
+    /**
+     * Adds some spotlight content that displays an item. It will also link the recipe for that item and cause a page flip.
+     */
+    public EntryBuilder item(ItemLike stack) {
+        return this.item(new ItemStack(stack), true);
+    }
+
+    /**
+     * Adds some spotlight content that displays an item. It will also cause a page flip.
+     */
+    public EntryBuilder item(ItemLike stack, boolean linkRecipe) {
+        return this.item(new ItemStack(stack), linkRecipe);
+    }
+    
+    /**
+     * Adds some spotlight content that displays an item. It will also link the recipe for that item and cause a page flip.
+     */
+    public EntryBuilder item(ItemStack stack) {
+        return this.item(stack, true);
+    }
+    
+    /**
+     * Adds some spotlight content that displays an item. It will also cause a page flip.
+     */
+    public EntryBuilder item(ItemStack stack, boolean linkRecipe) {
+        return this.add(new SpotlightContent(stack, linkRecipe));
+    }
+
+    /**
+     * Adds some content to the entry that display the given entity.
+     */
+    public EntryBuilder entity(EntityType<?> entity) {
+        return this.add(new EntityContent(entity));
+    }
+
+    /**
+     * Adds some content to the entry that display a multiblock.
+     * 
+     * @param data The multiblock data as recognised by patchouli.
+     */
+    public EntryBuilder multiblock(String title, String data) {
+        return this.add(new MultiblockContent(title, data));
+    }
+
+    /**
+     * Adds the given content to this entry.
+     */
+    public EntryBuilder add(Content content) {
+        this.content = this.content.with(content);
+        return this;
+    }
+    
+    /**
+     * Adds a {@link Consumer} that can modify the final json data after it is built.
+     */
+    public EntryBuilder postProcess(Consumer<JsonObject> postProcessor) {
+        this.postProcessors.add(postProcessor);
+        return this;
+    }
+    
+    JsonObject build(BiFunction<String, List<String>, String> translations, ExistingFileHelper fileHelper) {
+        if (this.name == null) throw new IllegalStateException("Entry name not set: " + this.category + "/" + this.id);
+        if (this.icon == null) throw new IllegalStateException("Entry icon not set: " + this.category + "/" + this.id);
+        JsonObject json = new JsonObject();
+        json.addProperty("name", translations.apply(this.name, List.of("entry", this.category.getNamespace(), this.category.getPath(), this.id)));
+        json.addProperty("category", this.category.toString());
+        json.add("icon", PageJson.stack(this.icon));
+        if (this.advancement != null) {
+            json.addProperty("advancement", this.advancement.toString());
+        }
+
+        JsonArray pages = new JsonArray();
+        PageBuilder builder = new PageBuilder() {
+            
+            private int page = 0;
+            private int key = 0;
+            private String anchor = null;
+
+            @Override
+            public boolean isFirst() {
+                return this.page == 0;
+            }
+
+            @Override
+            public void addPage(JsonObject page) {
+                this.page += 1;
+                this.key = 0;
+                if (this.anchor != null) {
+                    if (page.has("anchor")) {
+                        throw new IllegalStateException("Can't add pending anchor '" + this.anchor + "', page already has an anchor set: '" + page.get("anchor").getAsString() + "'");
+                    } else {
+                        page.addProperty("anchor", this.anchor);
+                        this.anchor = null;
+                    }
+                }
+                pages.add(page);
+            }
+
+            @Override
+            public void addAnchor(String name) {
+                if (this.anchor != null) {
+                    throw new IllegalStateException("Can't add anchor '" + name + "', already a pending anchor: '" + this.anchor + "'");
+                } else {
+                    this.anchor = name;
+                }
+            }
+
+            @Override
+            public String translate(String localized) {
+                return translations.apply(localized, List.of("entry", EntryBuilder.this.category.getNamespace(), EntryBuilder.this.category.getPath(), EntryBuilder.this.id, "page" + this.page, "text" + (this.key++)));
+            }
+
+            @Override
+            public void flipToEven() {
+                if ((this.page % 2) != 0) {
+                    JsonObject json = new JsonObject();
+                    json.addProperty("type", "patchouli:empty");
+                    this.addPage(json);
+                }
+            }
+
+            @Override
+            public void checkAssets(ResourceLocation path) {
+                if (!fileHelper.exists(path, PackType.CLIENT_RESOURCES)) {
+                    throw new IllegalStateException("Resource " + path + " does not exist.");
+                }
+            }
+        };
+        
+        this.content.pages(builder);
+        json.add("pages", pages);
+        
+        for (Consumer<JsonObject> postProcessor : this.postProcessors) {
+            postProcessor.accept(json);
+        }
+        
+        return json;
+    }
+}

--- a/src/main/java/org/moddingx/libx/datagen/provider/patchouli/PatchouliProviderBase.java
+++ b/src/main/java/org/moddingx/libx/datagen/provider/patchouli/PatchouliProviderBase.java
@@ -1,0 +1,131 @@
+package org.moddingx.libx.datagen.provider.patchouli;
+
+import net.minecraft.data.CachedOutput;
+import net.minecraft.data.DataGenerator;
+import net.minecraft.data.DataProvider;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.PackType;
+import net.minecraftforge.common.data.ExistingFileHelper;
+import org.moddingx.libx.impl.datagen.FontLoader;
+import org.moddingx.libx.impl.datagen.patchouli.translate.TranslationManager;
+import org.moddingx.libx.mod.ModX;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiFunction;
+
+/**
+ * A provider for patchouli categories and entries. This will not generate the {@code book.json} file.
+ */
+public abstract class PatchouliProviderBase implements DataProvider {
+    
+    protected final ModX mod;
+    protected final DataGenerator generator;
+    protected final ExistingFileHelper fileHelper;
+    private final BookProperties properties;
+    
+    private final List<CategoryBuilder> categories;
+    private final Set<ResourceLocation> categoryIds;
+    private final List<EntryBuilder> entries;
+    
+    public PatchouliProviderBase(ModX mod, DataGenerator generator, ExistingFileHelper fileHelper, BookProperties properties) {
+        this.mod = mod;
+        this.generator = generator;
+        this.fileHelper = fileHelper;
+        this.properties = properties;
+        FontLoader.getFontWidthProvider(fileHelper);
+        
+        this.categories = new ArrayList<>();
+        this.categoryIds = new HashSet<>();
+        this.entries = new ArrayList<>();
+    }
+
+    /**
+     * Creates the categories and entries for the patchouli book.
+     */
+    protected abstract void setup();
+
+    /**
+     * Adds a new category to this book.
+     * 
+     * @see CategoryBuilder
+     */
+    public CategoryBuilder category(String id) {
+        CategoryBuilder builder = new CategoryBuilder(this.mod.resource(id));
+        this.categories.add(builder);
+        this.categoryIds.add(builder.id);
+        return builder;
+    }
+
+    /**
+     * Adds a new entry to this book. The entry will be added to the last added category.
+     *
+     * @see EntryBuilder
+     */
+    public EntryBuilder entry(String id) {
+        if (this.categories.isEmpty()) throw new IllegalStateException("No categories defined");
+        return this.entry(id, this.categories.get(this.categories.size() - 1).id);
+    }
+
+    /**
+     * Adds a new entry to this book.
+     *
+     * @see EntryBuilder
+     */
+    public EntryBuilder entry(String id, String category) {
+        return this.entry(id, this.mod.resource(category));
+    }
+
+    /**
+     * Adds a new entry to this book.
+     *
+     * @see EntryBuilder
+     */
+    public EntryBuilder entry(String id, ResourceLocation category) {
+        if (this.mod.modid.equals(category.getNamespace()) && !this.categoryIds.contains(category)) throw new IllegalArgumentException("Unknown category: " + category);
+        EntryBuilder builder = new EntryBuilder(id, category);
+        this.entries.add(builder);
+        return builder;
+    }
+
+    @Nonnull
+    @Override
+    public String getName() {
+        return this.mod.modid + " " + this.properties.bookName() + " patchouli book";
+    }
+    
+    @Override
+    public void run(@Nonnull CachedOutput cache) throws IOException {
+        this.setup();
+        
+        TranslationManager mgr;
+        BiFunction<String, List<String>, String> translations;
+        if (this.properties.translate()) {
+            mgr = new TranslationManager(this.properties.bookName());
+            translations = mgr::add;
+        } else {
+            mgr = null;
+            translations = (str, path) -> str;
+        }
+        
+        for (int i = 0; i < this.categories.size(); i++) {
+            CategoryBuilder category = this.categories.get(i);
+            Path path = this.generator.getOutputFolder().resolve(this.properties.packTarget().getDirectory() + "/" + category.id.getNamespace() + "/patchouli_books/" + this.properties.bookName() + "/en_us/categories/" + category.id.getPath() + ".json");
+            DataProvider.saveStable(cache, category.build(translations, i), path);
+        }
+        for (EntryBuilder entry : this.entries) {
+            Path path = this.generator.getOutputFolder().resolve(this.properties.packTarget().getDirectory() + "/" + entry.category.getNamespace() + "/patchouli_books/" + this.properties.bookName() + "/en_us/entries/" + entry.category.getPath() + "/" + entry.id + ".json");
+            DataProvider.saveStable(cache, entry.build(translations, this.fileHelper), path);
+        }
+
+        if (mgr != null) {
+            Path langPath = this.generator.getOutputFolder().resolve(PackType.CLIENT_RESOURCES.getDirectory() + "/" + this.mod.modid + "_" + this.properties.bookName() + "/lang/en_us.json");
+            DataProvider.saveStable(cache, mgr.build(), langPath);
+        }
+    }
+}

--- a/src/main/java/org/moddingx/libx/datagen/provider/patchouli/PatchouliProviderBase.java
+++ b/src/main/java/org/moddingx/libx/datagen/provider/patchouli/PatchouliProviderBase.java
@@ -6,6 +6,7 @@ import net.minecraft.data.DataProvider;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.PackType;
 import net.minecraftforge.common.data.ExistingFileHelper;
+import org.moddingx.libx.annotation.meta.Experimental;
 import org.moddingx.libx.impl.datagen.FontLoader;
 import org.moddingx.libx.impl.datagen.patchouli.translate.TranslationManager;
 import org.moddingx.libx.mod.ModX;
@@ -22,6 +23,7 @@ import java.util.function.BiFunction;
 /**
  * A provider for patchouli categories and entries. This will not generate the {@code book.json} file.
  */
+@Experimental
 public abstract class PatchouliProviderBase implements DataProvider {
     
     protected final ModX mod;

--- a/src/main/java/org/moddingx/libx/datagen/provider/patchouli/content/CaptionContent.java
+++ b/src/main/java/org/moddingx/libx/datagen/provider/patchouli/content/CaptionContent.java
@@ -1,5 +1,6 @@
 package org.moddingx.libx.datagen.provider.patchouli.content;
 
+import org.moddingx.libx.annotation.meta.Experimental;
 import org.moddingx.libx.datagen.provider.patchouli.page.Content;
 import org.moddingx.libx.datagen.provider.patchouli.page.PageBuilder;
 import org.moddingx.libx.datagen.provider.patchouli.page.PageJson;
@@ -11,6 +12,7 @@ import java.util.List;
  * Base class for pages with some special content that can be followed by some text. This class will handle
  * merging with other caption content and splitting the text up on multiple pages if required.
  */
+@Experimental
 public abstract class CaptionContent implements Content {
     
     @Nullable

--- a/src/main/java/org/moddingx/libx/datagen/provider/patchouli/content/CaptionContent.java
+++ b/src/main/java/org/moddingx/libx/datagen/provider/patchouli/content/CaptionContent.java
@@ -1,0 +1,68 @@
+package org.moddingx.libx.datagen.provider.patchouli.content;
+
+import org.moddingx.libx.datagen.provider.patchouli.page.Content;
+import org.moddingx.libx.datagen.provider.patchouli.page.PageBuilder;
+import org.moddingx.libx.datagen.provider.patchouli.page.PageJson;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+/**
+ * Base class for pages with some special content that can be followed by some text. This class will handle
+ * merging with other caption content and splitting the text up on multiple pages if required.
+ */
+public abstract class CaptionContent implements Content {
+    
+    @Nullable
+    protected final String caption;
+
+    protected CaptionContent(@Nullable String caption) {
+        this.caption = caption;
+    }
+
+    /**
+     * Gets the amount of lines, that should be skipped for the special content.
+     */
+    protected abstract int lineSkip();
+
+    /**
+     * Creates a copy of this {@link CaptionContent} with a new caption set.
+     */
+    protected abstract CaptionContent withCaption(String caption);
+
+    /**
+     * Builds the special page for this {@link CaptionContent}.
+     * 
+     * @param caption The text for that special page. All other text is added to regular text pages after this one.
+     */
+    protected abstract void specialPage(PageBuilder builder, @Nullable String caption);
+
+    /**
+     * Gets whether regular (non-caption) text can merge to this {@link CaptionContent}. Default is {@code false}.
+     */
+    protected boolean canTakeRegularText() {
+        return false;
+    }
+    
+    @Override
+    public void pages(PageBuilder builder) {
+        List<String> pages = this.caption == null ? List.of() : PageJson.splitText(this.caption, this.lineSkip());
+        if (pages.isEmpty()) {
+            this.specialPage(builder, null);
+        } else if (pages.size() == 1) {
+            this.specialPage(builder, pages.get(0));
+        } else {
+            this.specialPage(builder, pages.get(0));
+            TextContent.addTextPages(builder, pages, false);
+        }
+    }
+
+    @Override
+    public Content with(Content next) {
+        if (next instanceof TextContent tc && (this.canTakeRegularText() || tc.caption())) {
+            return this.withCaption(this.caption == null ? tc.text() : this.caption + " " + tc.text());
+        } else {
+            return Content.super.with(next);
+        }
+    }
+}

--- a/src/main/java/org/moddingx/libx/datagen/provider/patchouli/content/RecipePage.java
+++ b/src/main/java/org/moddingx/libx/datagen/provider/patchouli/content/RecipePage.java
@@ -1,0 +1,56 @@
+package org.moddingx.libx.datagen.provider.patchouli.content;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import net.minecraft.resources.ResourceLocation;
+import org.moddingx.libx.datagen.provider.patchouli.page.PageBuilder;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+/**
+ * Content for pages with a single recipe followed by some text.
+ */
+public abstract class RecipePage extends CaptionContent {
+
+    protected final String pageType;
+    protected final List<ResourceLocation> recipes;
+
+    public RecipePage(String pageType, ResourceLocation... recipes) {
+        this(pageType, List.of(recipes), null);
+    }
+    
+    protected RecipePage(String pageType, List<ResourceLocation> recipes, @Nullable String caption) {
+        super(caption);
+        this.pageType = pageType;
+        this.recipes = List.copyOf(recipes);
+    }
+
+    /**
+     * Adds the recipe to the generated json. The default implementation will add the recipe id under a key named
+     * {@code recipe} if there is exactly one recipe. If there are multiple recipes, an array of all keys is created
+     * instead.
+     */
+    protected void addRecipeKey(JsonObject json) {
+        if (this.recipes.size() != 1) {
+            JsonArray array = new JsonArray();
+            for (ResourceLocation recipe : this.recipes) {
+                array.add(recipe.toString());
+            }
+            json.add("recipe", array);
+        } else {
+            json.addProperty("recipe", this.recipes.get(0).toString());
+        }
+    }
+    
+    @Override
+    protected void specialPage(PageBuilder builder, @Nullable String caption) {
+        JsonObject json = new JsonObject();
+        json.addProperty("type", this.pageType);
+        this.addRecipeKey(json);
+        if (caption != null) {
+            json.addProperty("text", builder.translate(caption));
+        }
+        builder.addPage(json);
+    }
+}

--- a/src/main/java/org/moddingx/libx/datagen/provider/patchouli/content/RecipePage.java
+++ b/src/main/java/org/moddingx/libx/datagen/provider/patchouli/content/RecipePage.java
@@ -3,6 +3,7 @@ package org.moddingx.libx.datagen.provider.patchouli.content;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import net.minecraft.resources.ResourceLocation;
+import org.moddingx.libx.annotation.meta.Experimental;
 import org.moddingx.libx.datagen.provider.patchouli.page.PageBuilder;
 
 import javax.annotation.Nullable;
@@ -11,6 +12,7 @@ import java.util.List;
 /**
  * Content for pages with a single recipe followed by some text.
  */
+@Experimental
 public abstract class RecipePage extends CaptionContent {
 
     protected final String pageType;

--- a/src/main/java/org/moddingx/libx/datagen/provider/patchouli/content/TextContent.java
+++ b/src/main/java/org/moddingx/libx/datagen/provider/patchouli/content/TextContent.java
@@ -1,6 +1,7 @@
 package org.moddingx.libx.datagen.provider.patchouli.content;
 
 import com.google.gson.JsonObject;
+import org.moddingx.libx.annotation.meta.Experimental;
 import org.moddingx.libx.datagen.provider.patchouli.page.Content;
 import org.moddingx.libx.datagen.provider.patchouli.page.PageBuilder;
 import org.moddingx.libx.datagen.provider.patchouli.page.PageJson;
@@ -13,6 +14,7 @@ import java.util.List;
  * 
  * @param caption Whether this {@link TextContent} is a caption content.
  */
+@Experimental
 public record TextContent(String text, boolean caption) implements Content {
 
     @Override

--- a/src/main/java/org/moddingx/libx/datagen/provider/patchouli/content/TextContent.java
+++ b/src/main/java/org/moddingx/libx/datagen/provider/patchouli/content/TextContent.java
@@ -1,0 +1,41 @@
+package org.moddingx.libx.datagen.provider.patchouli.content;
+
+import com.google.gson.JsonObject;
+import org.moddingx.libx.datagen.provider.patchouli.page.Content;
+import org.moddingx.libx.datagen.provider.patchouli.page.PageBuilder;
+import org.moddingx.libx.datagen.provider.patchouli.page.PageJson;
+
+import java.util.List;
+
+/**
+ * Content that generates one or multiple text pages and automatically wraps the text. Multiple text
+ * contents that are added after each other will merge to a single one.
+ * 
+ * @param caption Whether this {@link TextContent} is a caption content.
+ */
+public record TextContent(String text, boolean caption) implements Content {
+
+    @Override
+    public void pages(PageBuilder builder) {
+        List<String> pages = PageJson.splitText(this.text(), builder.isFirst());
+        addTextPages(builder, pages, true);
+    }
+
+    @Override
+    public Content with(Content next) {
+        if (next instanceof TextContent tc && (!this.caption() || tc.caption())) {
+            return new TextContent(this.text() + " " + tc.text(), this.caption());
+        } else {
+            return Content.super.with(next);
+        }
+    }
+
+    public static void addTextPages(PageBuilder builder, List<String> pages, boolean includeFirst) {
+        for (String page : (includeFirst ? pages : pages.stream().skip(1).toList())) {
+            JsonObject json = new JsonObject();
+            json.addProperty("type", "patchouli:text");
+            json.addProperty("text", builder.translate(page));
+            builder.addPage(json);
+        }
+    }
+}

--- a/src/main/java/org/moddingx/libx/datagen/provider/patchouli/page/Content.java
+++ b/src/main/java/org/moddingx/libx/datagen/provider/patchouli/page/Content.java
@@ -1,5 +1,6 @@
 package org.moddingx.libx.datagen.provider.patchouli.page;
 
+import org.moddingx.libx.annotation.meta.Experimental;
 import org.moddingx.libx.datagen.provider.patchouli.EntryBuilder;
 import org.moddingx.libx.impl.datagen.patchouli.content.CompositeContent;
 
@@ -14,6 +15,7 @@ import java.util.List;
  * content is merged with some caption content, both of them will result in a single content that adds a
  * recipe page with text.
  */
+@Experimental
 public interface Content {
 
     /**

--- a/src/main/java/org/moddingx/libx/datagen/provider/patchouli/page/Content.java
+++ b/src/main/java/org/moddingx/libx/datagen/provider/patchouli/page/Content.java
@@ -1,0 +1,36 @@
+package org.moddingx.libx.datagen.provider.patchouli.page;
+
+import org.moddingx.libx.datagen.provider.patchouli.EntryBuilder;
+import org.moddingx.libx.impl.datagen.patchouli.content.CompositeContent;
+
+import java.util.List;
+
+/**
+ * Defines some content for a {@link EntryBuilder patchouli book entry}.
+ * A content is something that can create zero, one or multiple actual book pages, when built.
+ * Each book entry will only ever have one single {@link Content}. When new content is added to the entry,
+ * it is chained to the previous content using {@link #with(Content)}.
+ * Subclasses may override this to allow for content to merge on the same page. For example, when a recipe
+ * content is merged with some caption content, both of them will result in a single content that adds a
+ * recipe page with text.
+ */
+public interface Content {
+
+    /**
+     * An empty content that does nothing.
+     */
+    Content EMPTY = new CompositeContent(List.of());
+
+    /**
+     * Generates some pages for this content.
+     */
+    void pages(PageBuilder builder);
+
+    /**
+     * Chains a new content with this one. The default implementation returns a content, that just calls
+     * both {@link #pages(PageBuilder)} methods after each other.
+     */
+    default Content with(Content next) {
+        return new CompositeContent(List.of(this, next));
+    }
+}

--- a/src/main/java/org/moddingx/libx/datagen/provider/patchouli/page/PageBuilder.java
+++ b/src/main/java/org/moddingx/libx/datagen/provider/patchouli/page/PageBuilder.java
@@ -2,11 +2,13 @@ package org.moddingx.libx.datagen.provider.patchouli.page;
 
 import com.google.gson.JsonObject;
 import net.minecraft.resources.ResourceLocation;
+import org.moddingx.libx.annotation.meta.Experimental;
 import org.moddingx.libx.datagen.provider.patchouli.BookProperties;
 
 /**
  * An interface that defines methods, instances of {@link Content} can use to build book pages.
  */
+@Experimental
 public interface PageBuilder {
 
     /**

--- a/src/main/java/org/moddingx/libx/datagen/provider/patchouli/page/PageBuilder.java
+++ b/src/main/java/org/moddingx/libx/datagen/provider/patchouli/page/PageBuilder.java
@@ -1,0 +1,43 @@
+package org.moddingx.libx.datagen.provider.patchouli.page;
+
+import com.google.gson.JsonObject;
+import net.minecraft.resources.ResourceLocation;
+import org.moddingx.libx.datagen.provider.patchouli.BookProperties;
+
+/**
+ * An interface that defines methods, instances of {@link Content} can use to build book pages.
+ */
+public interface PageBuilder {
+
+    /**
+     * Gets whether the next added page will be the first page of an entry.
+     */
+    boolean isFirst();
+
+    /**
+     * Adds a new page from the given json data.
+     */
+    void addPage(JsonObject page);
+
+    /**
+     * Adds a new floating anchor. A floating anchor is added to the next page that is added via {@link #addPage(JsonObject)}.
+     * There may only ever be one floating anchor at a time and the next page after a floating anchor may not add an anchor itself.
+     */
+    void addAnchor(String name);
+
+    /**
+     * Gets a string that should be used in the book for the given text. Depending on the {@link BookProperties properties}, this
+     * will either register a translation and return the translation key or will return the text itself.
+     */
+    String translate(String localized);
+
+    /**
+     * Inserts an empty page, if necessary, so the next added page will have an even page number.
+     */
+    void flipToEven();
+
+    /**
+     * Checks that a given asset exists, Throws an exception if not.
+     */
+    void checkAssets(ResourceLocation path);
+}

--- a/src/main/java/org/moddingx/libx/datagen/provider/patchouli/page/PageJson.java
+++ b/src/main/java/org/moddingx/libx/datagen/provider/patchouli/page/PageJson.java
@@ -10,6 +10,7 @@ import net.minecraft.network.chat.Style;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.registries.ForgeRegistries;
+import org.moddingx.libx.annotation.meta.Experimental;
 import org.moddingx.libx.impl.datagen.FontLoader;
 
 import java.util.ArrayList;
@@ -19,6 +20,7 @@ import java.util.stream.Collectors;
 /**
  * Some utilities for creating pages in a patchouli book.
  */
+@Experimental
 public class PageJson {
 
     /**

--- a/src/main/java/org/moddingx/libx/datagen/provider/patchouli/page/PageJson.java
+++ b/src/main/java/org/moddingx/libx/datagen/provider/patchouli/page/PageJson.java
@@ -1,0 +1,140 @@
+package org.moddingx.libx.datagen.provider.patchouli.page;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import net.minecraft.client.StringSplitter;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.FormattedText;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.Style;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.registries.ForgeRegistries;
+import org.moddingx.libx.impl.datagen.FontLoader;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Some utilities for creating pages in a patchouli book.
+ */
+public class PageJson {
+
+    /**
+     * Gets a {@link JsonElement} that represents the given {@link ItemStack} in the format, patchouli requires it.
+     */
+    public static JsonElement stack(ItemStack stack) {
+        StringBuilder sb = new StringBuilder();
+        ResourceLocation id = ForgeRegistries.ITEMS.getKey(stack.getItem());
+        if (id == null) throw new IllegalStateException("Item not registered: " + stack);
+        sb.append(id.getNamespace());
+        sb.append(":");
+        sb.append(id.getPath());
+        if (stack.getCount() != 1) {
+            sb.append("#");
+            sb.append(stack.getCount());
+        }
+        if (stack.hasTag() && !stack.getOrCreateTag().isEmpty()) {
+            sb.append(stack.getOrCreateTag());
+        }
+        return new JsonPrimitive(sb.toString());
+    }
+
+    /**
+     * Splits the given text onto multiple full text pages.
+     */
+    public static List<String> splitText(String text) {
+        return splitText(text, false);
+    }
+    
+    /**
+     * Splits the given text onto multiple full text pages.
+     * 
+     * @param withInit Whether the first text page should be a little bit smaller, so there is enough space for the
+     *                 entry header.
+     */
+    public static List<String> splitText(String text, boolean withInit) {
+        return splitText(text, withInit ? 14 : 16, 16);
+    }
+
+    /**
+     * Splits the given text onto multiple text pages.
+     * 
+     * @param skip How many lines, the first page should be shorter that usual.
+     */
+    public static List<String> splitText(String text, int skip) {
+        return splitText(text, Math.max(16 - skip, 1), 16);
+    }
+    
+    /**
+     * Splits the given text onto multiple text pages.
+     * 
+     * @param linesHead The amount of lines on the first page.
+     * @param linesTail The amount of lines on all other pages.
+     */
+    public static List<String> splitText(String text, int linesHead, int linesTail) {
+        Component displayText = displayText(text);
+        StringSplitter.WidthProvider width = FontLoader.getFontWidthProvider(null);
+        StringSplitter splitter = new StringSplitter((codePoint, style) -> style.isObfuscated() ? 0 : width.getWidth(codePoint, style));
+        List<String> lines = splitter.splitLines(displayText, Math.round(116 * 1.65f), Style.EMPTY).stream().map(FormattedText::getString).map(String::strip).filter(s -> !s.isEmpty()).toList();
+        List<String> pages = new ArrayList<>();
+        boolean first = true;
+        while (!lines.isEmpty()) {
+            pages.add(lines.stream().limit(first ? linesHead : linesTail).collect(Collectors.joining(" ")));
+            lines = lines.stream().skip(first ? linesHead : linesTail).toList();
+            first = false;
+        }
+        return List.copyOf(pages);
+    }
+    
+    // Make a component, where formatting codes have an obfuscated style, so they can be 0 width in
+    // our custom width provider.
+    private static Component displayText(String text) {
+        Style obfuscated = Style.EMPTY.withObfuscated(true);
+        MutableComponent display = Component.empty();
+        
+        StringBuilder current = new StringBuilder();
+        StringBuilder currentFmt = new StringBuilder();
+        for (int idx = 0; idx < text.length();) {
+            if (text.charAt(idx) == '$' && idx + 1 < text.length() && text.charAt(idx + 1) == '(') {
+                if (!current.isEmpty()) {
+                    display.append(Component.literal(current.toString()).setStyle(Style.EMPTY));
+                    current = new StringBuilder();
+                }
+                int openCodes = 1;
+                currentFmt.append("$(");
+                idx += 2;
+                while (openCodes > 0 && idx < text.length()) {
+                    // Handle nested codes
+                    if (text.charAt(idx) == '$' && idx + 1 < text.length() && text.charAt(idx + 1) == '(') {
+                        currentFmt.append("$(");
+                        openCodes += 1;
+                        idx += 2;
+                    } else if (text.charAt(idx) == ')') {
+                        currentFmt.append(")");
+                        openCodes -= 1;
+                        idx += 1;
+                    } else {
+                        currentFmt.append(text.charAt(idx));
+                        idx += 1;
+                    }
+                }
+            } else {
+                if (!currentFmt.isEmpty()) {
+                    display.append(Component.literal(currentFmt.toString()).setStyle(obfuscated));
+                    currentFmt = new StringBuilder();
+                }
+                current.append(text.charAt(idx));
+                idx += 1;
+            }
+        }
+        if (!current.isEmpty()) {
+            display.append(Component.literal(current.toString()).setStyle(Style.EMPTY));
+        }
+        if (!currentFmt.isEmpty()) {
+            display.append(Component.literal(currentFmt.toString()).setStyle(obfuscated));
+        }
+        return display;
+    }
+}

--- a/src/main/java/org/moddingx/libx/impl/datagen/FontLoader.java
+++ b/src/main/java/org/moddingx/libx/impl/datagen/FontLoader.java
@@ -1,0 +1,47 @@
+package org.moddingx.libx.impl.datagen;
+
+import net.minecraft.client.StringSplitter;
+import net.minecraft.client.gui.font.glyphs.SpecialGlyphs;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.PackType;
+import net.minecraft.server.packs.resources.Resource;
+import net.minecraftforge.common.data.ExistingFileHelper;
+import org.moddingx.libx.LibX;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class FontLoader {
+
+    private static StringSplitter.WidthProvider widthProvider;
+
+    public static StringSplitter.WidthProvider getFontWidthProvider(@Nullable ExistingFileHelper fileHelper) {
+        if (widthProvider == null) {
+            if (fileHelper == null) {
+                throw new RuntimeException("Can't load font without file helper.");
+            }
+            try {
+                Resource res = fileHelper.getResource(new ResourceLocation("minecraft", "font/glyph_sizes.bin"), PackType.CLIENT_RESOURCES);
+                byte[] sizes;
+                try (InputStream in = res.open()) {
+                    sizes = in.readAllBytes();
+                }
+                
+                widthProvider = (codePoint, style) -> {
+                    if (codePoint >= 0 && codePoint < sizes.length) {
+                        int data = sizes[codePoint];
+                        if (data == 0) return 0;
+                        return (data & 0b1111) - ((data >> 4) & 0b1111) + 1;
+                    }
+                    return SpecialGlyphs.MISSING.getAdvance(style.isBold());
+                };
+            } catch (IOException e) {
+                LibX.logger.error("Failed to load glyph sizes during datagen. Using Missing glyph provider.", e);
+                widthProvider = (codePoint, style) -> SpecialGlyphs.MISSING.getAdvance(style.isBold());
+            }
+
+        }
+        return widthProvider;
+    }
+}

--- a/src/main/java/org/moddingx/libx/impl/datagen/patchouli/content/CompositeContent.java
+++ b/src/main/java/org/moddingx/libx/impl/datagen/patchouli/content/CompositeContent.java
@@ -1,0 +1,41 @@
+package org.moddingx.libx.impl.datagen.patchouli.content;
+
+import org.moddingx.libx.datagen.provider.patchouli.page.Content;
+import org.moddingx.libx.datagen.provider.patchouli.page.PageBuilder;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+public final class CompositeContent implements Content {
+
+    private final List<Content> children;
+
+    public CompositeContent(List<Content> children) {
+        this(children.stream());
+    }
+    
+    private CompositeContent(Stream<Content> children) {
+        this.children = children.flatMap(c -> {
+            if (c instanceof CompositeContent composite) {
+                return composite.children.stream();
+            } else {
+                return Stream.of(c);
+            }
+        }).toList();
+    }
+
+    @Override
+    public void pages(PageBuilder builder) {
+        this.children.forEach(c -> c.pages(builder));
+    }
+
+    @Override
+    public Content with(Content next) {
+        if (this.children.isEmpty()) return next;
+        // Merge to last child and then join back to composite
+        return new CompositeContent(Stream.concat(
+                this.children.stream().limit(this.children.size() - 1),
+                Stream.of(this.children.get(this.children.size() - 1).with(next))
+        ));
+    }
+}

--- a/src/main/java/org/moddingx/libx/impl/datagen/patchouli/content/DoubleRecipePage.java
+++ b/src/main/java/org/moddingx/libx/impl/datagen/patchouli/content/DoubleRecipePage.java
@@ -1,0 +1,75 @@
+package org.moddingx.libx.impl.datagen.patchouli.content;
+
+import com.google.gson.JsonObject;
+import net.minecraft.resources.ResourceLocation;
+import org.moddingx.libx.datagen.provider.patchouli.content.CaptionContent;
+import org.moddingx.libx.datagen.provider.patchouli.content.TextContent;
+import org.moddingx.libx.datagen.provider.patchouli.page.Content;
+import org.moddingx.libx.datagen.provider.patchouli.page.PageBuilder;
+
+import javax.annotation.Nullable;
+
+public class DoubleRecipePage extends CaptionContent {
+
+    private final String pageType;
+    private final int skip;
+    private final ResourceLocation recipe1;
+    
+    @Nullable
+    private final ResourceLocation recipe2;
+    public DoubleRecipePage(String pageType, int skip, ResourceLocation recipe) {
+        this(pageType, skip, recipe, null, null);
+    }
+    
+    private DoubleRecipePage(String pageType, int skip, ResourceLocation recipe1, @Nullable ResourceLocation recipe2, String caption) {
+        super(caption);
+        this.pageType = pageType;
+        this.skip = skip;
+        this.recipe1 = recipe1;
+        this.recipe2 = recipe2;
+    }
+    
+    @Override
+    protected int lineSkip() {
+        return this.recipe2 == null ? this.skip : this.skip * 2;
+    }
+
+    @Override
+    protected CaptionContent withCaption(String caption) {
+        return new DoubleRecipePage(this.pageType, this.skip, this.recipe1, this.recipe2, caption);
+    }
+
+    @Override
+    public void pages(PageBuilder builder) {
+        if (this.lineSkip() >= 16 && this.caption != null) {
+            this.withCaption(null).pages(builder);
+            new TextContent(this.caption, false).pages(builder);
+        } else {
+            super.pages(builder);
+        }
+    }
+
+    @Override
+    protected void specialPage(PageBuilder builder, @Nullable String caption) {
+        JsonObject json = new JsonObject();
+        json.addProperty("type", this.pageType);
+        json.addProperty("recipe", this.recipe1.toString());
+        if (this.recipe2 != null) {
+            json.addProperty("recipe2", this.recipe2.toString());
+        }
+        if (caption != null) {
+            json.addProperty("text", builder.translate(caption));
+        }
+        builder.addPage(json);
+    }
+
+    @Override
+    public Content with(Content next) {
+        if (this.recipe2 == null && next instanceof DoubleRecipePage recipe && this.pageType.equals(recipe.pageType) && recipe.recipe2 == null) {
+            String caption = this.caption == null ? recipe.caption : (recipe.caption == null ? this.caption : this.caption + " " + recipe.caption);
+            return new DoubleRecipePage(this.pageType, this.skip, this.recipe1, recipe.recipe1, caption);
+        } else {
+            return super.with(next);
+        }
+    }
+}

--- a/src/main/java/org/moddingx/libx/impl/datagen/patchouli/content/EntityContent.java
+++ b/src/main/java/org/moddingx/libx/impl/datagen/patchouli/content/EntityContent.java
@@ -1,0 +1,45 @@
+package org.moddingx.libx.impl.datagen.patchouli.content;
+
+import com.google.gson.JsonObject;
+import net.minecraft.world.entity.EntityType;
+import net.minecraftforge.registries.ForgeRegistries;
+import org.moddingx.libx.datagen.provider.patchouli.content.CaptionContent;
+import org.moddingx.libx.datagen.provider.patchouli.page.PageBuilder;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+public class EntityContent extends CaptionContent {
+    
+    private final EntityType<?> entity;
+
+    public EntityContent(EntityType<?> entity) {
+        this(entity, null);
+    }
+    
+    private EntityContent(EntityType<?> entity, @Nullable String caption) {
+        super(caption);
+        this.entity = entity;
+    }
+
+    @Override
+    protected int lineSkip() {
+        return 13;
+    }
+
+    @Override
+    protected CaptionContent withCaption(String caption) {
+        return new EntityContent(this.entity, caption);
+    }
+
+    @Override
+    protected void specialPage(PageBuilder builder, @Nullable String caption) {
+        JsonObject json = new JsonObject();
+        json.addProperty("type", "patchouli:entity");
+        json.addProperty("entity", Objects.requireNonNull(ForgeRegistries.ENTITY_TYPES.getKey(this.entity), "Entity not registered: " + this.entity).toString());
+        if (caption != null) {
+            json.addProperty("text", builder.translate(caption));
+        }
+        builder.addPage(json);
+    }
+}

--- a/src/main/java/org/moddingx/libx/impl/datagen/patchouli/content/FlipContent.java
+++ b/src/main/java/org/moddingx/libx/impl/datagen/patchouli/content/FlipContent.java
@@ -1,0 +1,17 @@
+package org.moddingx.libx.impl.datagen.patchouli.content;
+
+import org.moddingx.libx.datagen.provider.patchouli.page.Content;
+import org.moddingx.libx.datagen.provider.patchouli.page.PageBuilder;
+
+import javax.annotation.Nullable;
+
+// Adds nothing but does a page flip.
+public record FlipContent(@Nullable String anchor) implements Content {
+
+    @Override
+    public void pages(PageBuilder builder) {
+        if (this.anchor() != null) {
+            builder.addAnchor(this.anchor());
+        }
+    }
+}

--- a/src/main/java/org/moddingx/libx/impl/datagen/patchouli/content/ImageContent.java
+++ b/src/main/java/org/moddingx/libx/impl/datagen/patchouli/content/ImageContent.java
@@ -1,0 +1,49 @@
+package org.moddingx.libx.impl.datagen.patchouli.content;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import net.minecraft.resources.ResourceLocation;
+import org.moddingx.libx.datagen.provider.patchouli.content.CaptionContent;
+import org.moddingx.libx.datagen.provider.patchouli.page.PageBuilder;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class ImageContent extends CaptionContent {
+
+    private final String title;
+    private final List<ResourceLocation> images;
+    
+    public ImageContent(String title, List<ResourceLocation> images, @Nullable String caption) {
+        super(caption);
+        this.title = title;
+        this.images = List.copyOf(images);
+    }
+
+    @Override
+    protected int lineSkip() {
+        return 12;
+    }
+
+    @Override
+    protected CaptionContent withCaption(String caption) {
+        return new ImageContent(this.title, this.images, caption);
+    }
+
+    @Override
+    protected void specialPage(PageBuilder builder, @Nullable String caption) {
+        if (this.images.isEmpty()) throw new IllegalStateException("No images in image page");
+        this.images.forEach(builder::checkAssets);
+        JsonObject json = new JsonObject();
+        json.addProperty("type", "patchouli:image");
+        json.addProperty("title", builder.translate(this.title));
+        JsonArray array = new JsonArray();
+        this.images.forEach(rl -> array.add(rl.toString()));
+        json.add("images", array);
+        json.addProperty("border", true);
+        if (caption != null) {
+            json.addProperty("text", builder.translate(caption));
+        }
+        builder.addPage(json);
+    }
+}

--- a/src/main/java/org/moddingx/libx/impl/datagen/patchouli/content/MultiblockContent.java
+++ b/src/main/java/org/moddingx/libx/impl/datagen/patchouli/content/MultiblockContent.java
@@ -1,0 +1,49 @@
+package org.moddingx.libx.impl.datagen.patchouli.content;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import org.moddingx.libx.datagen.provider.patchouli.content.CaptionContent;
+import org.moddingx.libx.datagen.provider.patchouli.page.PageBuilder;
+
+import javax.annotation.Nullable;
+
+public class MultiblockContent extends CaptionContent {
+
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+    private final String title;
+    private final String multiblockData;
+
+    public MultiblockContent(String title, String multiblockData) {
+        this(title, multiblockData, null);
+    }
+    
+    public MultiblockContent(String title, String multiblockData, @Nullable String caption) {
+        super(caption);
+        this.title = title;
+        this.multiblockData = multiblockData;
+    }
+
+    @Override
+    protected int lineSkip() {
+        return 13;
+    }
+
+    @Override
+    protected CaptionContent withCaption(String caption) {
+        return new MultiblockContent(this.title, this.multiblockData, caption);
+    }
+
+    @Override
+    protected void specialPage(PageBuilder builder, @Nullable String caption) {
+        JsonObject json = new JsonObject();
+        json.addProperty("type", "patchouli:multiblock");
+        json.addProperty("name", builder.translate(this.title));
+        json.add("multiblock", GSON.fromJson(this.multiblockData, JsonObject.class));
+        if (caption != null) {
+            json.addProperty("text", builder.translate(caption));
+        }
+        builder.addPage(json);
+    }
+}

--- a/src/main/java/org/moddingx/libx/impl/datagen/patchouli/content/SpotlightContent.java
+++ b/src/main/java/org/moddingx/libx/impl/datagen/patchouli/content/SpotlightContent.java
@@ -1,0 +1,52 @@
+package org.moddingx.libx.impl.datagen.patchouli.content;
+
+import com.google.gson.JsonObject;
+import net.minecraft.world.item.ItemStack;
+import org.moddingx.libx.datagen.provider.patchouli.content.CaptionContent;
+import org.moddingx.libx.datagen.provider.patchouli.page.PageBuilder;
+import org.moddingx.libx.datagen.provider.patchouli.page.PageJson;
+
+import javax.annotation.Nullable;
+
+public class SpotlightContent extends CaptionContent {
+
+    private final ItemStack stack;
+    private final boolean recipe;
+    
+    public SpotlightContent(ItemStack stack, boolean recipe) {
+        this(stack, recipe, null);
+    }
+    
+    private SpotlightContent(ItemStack stack, boolean recipe, @Nullable String caption) {
+        super(caption);
+        this.stack = stack.copy();
+        this.recipe = recipe;
+    }
+
+    @Override
+    protected int lineSkip() {
+        return 4;
+    }
+
+    @Override
+    protected boolean canTakeRegularText() {
+        return true;
+    }
+
+    @Override
+    protected CaptionContent withCaption(String caption) {
+        return new SpotlightContent(this.stack, this.recipe, caption);
+    }
+
+    @Override
+    protected void specialPage(PageBuilder builder, @Nullable String caption) {
+        JsonObject json = new JsonObject();
+        json.addProperty("type", "patchouli:spotlight");
+        json.add("item", PageJson.stack(this.stack));
+        json.addProperty("link_recipe", this.recipe);
+        if (caption != null) {
+            json.addProperty("text", builder.translate(caption));
+        }
+        builder.addPage(json);
+    }
+}

--- a/src/main/java/org/moddingx/libx/impl/datagen/patchouli/translate/TranslationManager.java
+++ b/src/main/java/org/moddingx/libx/impl/datagen/patchouli/translate/TranslationManager.java
@@ -1,0 +1,34 @@
+package org.moddingx.libx.impl.datagen.patchouli.translate;
+
+import com.google.gson.JsonObject;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class TranslationManager {
+    
+    private final String prefix;
+    private final Map<String, String> translations;
+    
+    public TranslationManager(String prefix) {
+        this.prefix = prefix;
+        this.translations = new HashMap<>();
+    }
+    
+    public String add(String translated, List<String> nameElems) {
+        String fullName = Stream.concat(Stream.of(this.prefix), nameElems.stream()).filter(s -> !s.isEmpty()).collect(Collectors.joining("."));
+        this.translations.put(fullName, translated);
+        return fullName;
+    }
+    
+    public JsonObject build() {
+        JsonObject json = new JsonObject();
+        for (String key : this.translations.keySet().stream().sorted().toList()) {
+            json.addProperty(key, this.translations.get(key));
+        }
+        return json;
+    }
+}


### PR DESCRIPTION
Adds datagen for categories and entries of [Patchouli](https://github.com/VazkiiMods/Patchouli) books. Mostly taken from [MythicBotany](https://github.com/noeppi-noeppi/MythicBotany/tree/master/src/main/java/mythicbotany/data/patchouli), ported to 1.19 and made a little bit more configurable.
