### PR TITLE
Add config value mapper factories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,3 @@ task release {
     }
 }
 
-repositories {
-    mavenCentral()
-}

--- a/src/ap/java/org/moddingx/libx/annotation/config/RegisterMapper.java
+++ b/src/ap/java/org/moddingx/libx/annotation/config/RegisterMapper.java
@@ -3,7 +3,7 @@ package org.moddingx.libx.annotation.config;
 import java.lang.annotation.*;
 
 /**
- * Automatically registers a value mapper for the LibX config system. An annotated class
+ * Automatically registers a value mapper or mapper factory for the LibX config system. An annotated class
  * must define a public no-arg constructor.
  */
 @Retention(RetentionPolicy.SOURCE)

--- a/src/ap/java/org/moddingx/libx/annotation/processor/Classes.java
+++ b/src/ap/java/org/moddingx/libx/annotation/processor/Classes.java
@@ -18,6 +18,7 @@ public class Classes {
     public static final String CONFIG_MANAGER = "org.moddingx.libx.config.ConfigManager";
     public static final String VALUE_MAPPER = "org.moddingx.libx.config.mapper.ValueMapper";
     public static final String GENERIC_VALUE_MAPPER = "org.moddingx.libx.config.mapper.GenericValueMapper";
+    public static final String VALUE_MAPPER_FACTORY = "org.moddingx.libx.config.mapper.MapperFactory";
 
     public static final String MULTI_REGISTERABLE = "org.moddingx.libx.registration.MultiRegisterable";
     public static final String REGISTRY = "net.minecraft.core.Registry";

--- a/src/ap/java/org/moddingx/libx/annotation/processor/modinit/ModInit.java
+++ b/src/ap/java/org/moddingx/libx/annotation/processor/modinit/ModInit.java
@@ -54,8 +54,8 @@ public class ModInit  {
         this.models.add(new LoadableModel(classFqn, fieldName, modelNamespace.isEmpty() ? this.modid : modelNamespace, modelPath));
     }
 
-    public void addConfigMapper(String classFqn, @Nullable String requiresMod, boolean genericType) {
-        this.configMappers.add(new RegisteredMapper(classFqn, requiresMod, genericType));
+    public void addConfigMapper(String classFqn, String targetTypeSource, @Nullable String requiresMod, boolean genericType) {
+        this.configMappers.add(new RegisteredMapper(classFqn, targetTypeSource, requiresMod, genericType));
     }
 
     public void addConfig(String name, boolean client, @Nullable String requiresMod, String classFqn) {
@@ -130,7 +130,7 @@ public class ModInit  {
                 if (mapper.requiresMod() != null) {
                     writer.write("if(" + Classes.sourceName(Classes.PROCESSOR_INTERFACE) + ".isModLoaded(" + quote(mapper.requiresMod()) + ")){");
                 }
-                writer.write(Classes.sourceName(Classes.CONFIG_MANAGER) + ".registerValueMapper(" + quote(this.modid) + ",new " + mapper.classFqn() + (mapper.genericType() ? "<>" : "") + "());");
+                writer.write(Classes.sourceName(Classes.PROCESSOR_INTERFACE) + ".registerConfigMapper(mod,(" + mapper.targetTypeSource() + ")new " + mapper.classFqn() + (mapper.genericType() ? "<>" : "") + "());");
                 if (mapper.requiresMod() != null) {
                     writer.write("}");
                 }
@@ -139,7 +139,7 @@ public class ModInit  {
                 if (config.requiresMod() != null) {
                     writer.write("if(" + Classes.sourceName(Classes.PROCESSOR_INTERFACE) + ".isModLoaded(" + quote(config.requiresMod()) + ")){");
                 }
-                writer.write(Classes.sourceName(Classes.CONFIG_MANAGER) + ".registerConfig(" + Classes.sourceName(Classes.PROCESSOR_INTERFACE) + ".newRL(" + quote(this.modid) + "," + quote(config.name()) + ")," + config.classFqn() + ".class," + config.client() + ");");
+                writer.write(Classes.sourceName(Classes.PROCESSOR_INTERFACE) + ".registerConfig(mod," + quote(config.name()) + "," + config.classFqn() + ".class," + config.client() + ");");
                 if (config.requiresMod() != null) {
                     writer.write("}");
                 }

--- a/src/ap/java/org/moddingx/libx/annotation/processor/modinit/config/RegisterMapperProcessor.java
+++ b/src/ap/java/org/moddingx/libx/annotation/processor/modinit/config/RegisterMapperProcessor.java
@@ -24,15 +24,26 @@ public class RegisterMapperProcessor {
         }
         boolean simple = env.subTypeErasure(element.asType(), env.forClass(Classes.VALUE_MAPPER));
         boolean generic = env.subTypeErasure(element.asType(), env.forClass(Classes.GENERIC_VALUE_MAPPER));
-        if (simple && generic) {
-            env.messager().printMessage(Diagnostic.Kind.ERROR, "Can't register a value mapper that is both simple and generic.", element);
+        boolean factory = env.subTypeErasure(element.asType(), env.forClass(Classes.VALUE_MAPPER_FACTORY));
+        if ((simple && generic) || (simple && factory) || (generic && factory)) {
+            env.messager().printMessage(Diagnostic.Kind.ERROR, "Class annotated with @RegisterMapper must implement exactly one of ValueMapper, GenericValueMapper and MapperFactory.", element);
             return;
-        } else if (!simple && !generic) {
+        } else if (!simple && !generic && !factory) {
             env.messager().printMessage(Diagnostic.Kind.ERROR, "Can't use @RegisterMapper on class that is no value mapper.", element);
             return;
         }
+        
+        String targetTypeSource;
+        if (simple) {
+            targetTypeSource = Classes.sourceName(Classes.VALUE_MAPPER) + "<?, ?>";
+        } else if (generic) {
+            targetTypeSource = Classes.sourceName(Classes.GENERIC_VALUE_MAPPER) + "<?, ?, ?>";
+        } else {
+            targetTypeSource = Classes.sourceName(Classes.VALUE_MAPPER_FACTORY) + "<?>";
+        }
+        
         RegisterMapper registerMapper = element.getAnnotation(RegisterMapper.class);
         ModInit mod = env.getMod(element);
-        mod.addConfigMapper(parent.getQualifiedName() + "." + element.getSimpleName(), registerMapper.requiresMod().isEmpty() ? null : registerMapper.requiresMod(), !typeElem.getTypeParameters().isEmpty());
+        mod.addConfigMapper(parent.getQualifiedName() + "." + element.getSimpleName(), targetTypeSource, registerMapper.requiresMod().isEmpty() ? null : registerMapper.requiresMod(), !typeElem.getTypeParameters().isEmpty());
     }
 }

--- a/src/ap/java/org/moddingx/libx/annotation/processor/modinit/config/RegisteredMapper.java
+++ b/src/ap/java/org/moddingx/libx/annotation/processor/modinit/config/RegisteredMapper.java
@@ -2,6 +2,6 @@ package org.moddingx.libx.annotation.processor.modinit.config;
 
 import javax.annotation.Nullable;
 
-public record RegisteredMapper(String classFqn, @Nullable String requiresMod, boolean genericType) {
+public record RegisteredMapper(String classFqn, String targetTypeSource, @Nullable String requiresMod, boolean genericType) {
 
 }

--- a/src/main/java/org/moddingx/libx/annotation/impl/ProcessorInterface.java
+++ b/src/main/java/org/moddingx/libx/annotation/impl/ProcessorInterface.java
@@ -18,6 +18,10 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.IForgeRegistry;
 import net.minecraftforge.registries.RegistryManager;
 import org.moddingx.libx.codec.MoreCodecs;
+import org.moddingx.libx.config.ConfigManager;
+import org.moddingx.libx.config.mapper.GenericValueMapper;
+import org.moddingx.libx.config.mapper.MapperFactory;
+import org.moddingx.libx.config.mapper.ValueMapper;
 import org.moddingx.libx.impl.ModInternal;
 import org.moddingx.libx.impl.reflect.ReflectionHacks;
 import org.moddingx.libx.mod.ModX;
@@ -38,6 +42,22 @@ public class ProcessorInterface {
         return new ResourceLocation(namespace, path);
     }
     
+    public static void registerConfig(ModX mod, String name, Class<?> configClass, boolean client) {
+        ConfigManager.registerConfig(mod.resource(name), configClass, client);
+    }
+    
+    public static void registerConfigMapper(ModX mod, ValueMapper<?, ?> mapper) {
+        ConfigManager.registerValueMapper(mod.modid, mapper);
+    }
+    
+    public static void registerConfigMapper(ModX mod, GenericValueMapper<?, ?, ?> mapper) {
+        ConfigManager.registerValueMapper(mod.modid, mapper);
+    }
+    
+    public static void registerConfigMapper(ModX mod, MapperFactory<?> mapper) {
+        ConfigManager.registerValueMapperFactory(mod.modid, mapper);
+    }
+        
     public static void register(ModX mod, @Nullable ResourceKey<? extends Registry<?>> registryKey, String name, Object value, @Nullable FieldGetter field, boolean multi) throws ReflectiveOperationException {
         if (!(mod instanceof ModXRegistration reg)) throw new IllegalStateException("Can't register to a non-ModXRegistration mod.");
         if (multi) {
@@ -116,14 +136,14 @@ public class ProcessorInterface {
     }
     
     @FunctionalInterface
-    public static interface ThrowingRunnable {
+    public interface ThrowingRunnable {
         
-        public void run() throws Exception;
+        void run() throws Exception;
     }
     
     @FunctionalInterface
-    public static interface FieldGetter {
+    public interface FieldGetter {
         
-        public Field get() throws ReflectiveOperationException;
+        Field get() throws ReflectiveOperationException;
     }
 }

--- a/src/main/java/org/moddingx/libx/base/decoration/DecorationType.java
+++ b/src/main/java/org/moddingx/libx/base/decoration/DecorationType.java
@@ -55,7 +55,7 @@ public interface DecorationType<T> {
         //
     }
     
-    public static record DecorationElement<R, T extends R>(@Nullable ResourceKey<? extends Registry<R>> registry, T element) {
+    record DecorationElement<R, T extends R>(@Nullable ResourceKey<? extends Registry<R>> registry, T element) {
         
         public void registerTo(Registerable.EntryCollector builder) {
             builder.register(this.registry(), this.element());

--- a/src/main/java/org/moddingx/libx/config/ConfigManager.java
+++ b/src/main/java/org/moddingx/libx/config/ConfigManager.java
@@ -10,6 +10,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.loading.FMLEnvironment;
 import net.minecraftforge.fml.loading.FMLPaths;
 import net.minecraftforge.network.PacketDistributor;
@@ -17,6 +18,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
 import org.moddingx.libx.LibX;
 import org.moddingx.libx.config.mapper.GenericValueMapper;
+import org.moddingx.libx.config.mapper.MapperFactory;
 import org.moddingx.libx.config.mapper.ValueMapper;
 import org.moddingx.libx.config.validate.DoubleRange;
 import org.moddingx.libx.config.validator.ConfigValidator;
@@ -153,6 +155,9 @@ public class ConfigManager {
      * Registers a new {@link ValueMapper} that can be used to serialise config values.
      */
     public static void registerValueMapper(String modid, ValueMapper<?, ?> mapper) {
+        if (!Objects.equals(modid, ModLoadingContext.get().getActiveNamespace())) {
+            LibX.logger.error("Wrong modid for value mapper, expected " + ModLoadingContext.get().getActiveNamespace() + " got " + modid);
+        }
         ModMappers.get(modid).registerValueMapper(mapper);
     }
     
@@ -160,7 +165,20 @@ public class ConfigManager {
      * Registers a new {@link GenericValueMapper} that can be used to serialise config values.
      */
     public static void registerValueMapper(String modid, GenericValueMapper<?, ?, ?> mapper) {
+        if (!Objects.equals(modid, ModLoadingContext.get().getActiveNamespace())) {
+            LibX.logger.error("Wrong modid for generic value mapper, expected " + ModLoadingContext.get().getActiveNamespace() + " got " + modid);
+        }
         ModMappers.get(modid).registerValueMapper(mapper);
+    }
+    
+    /**
+     * Registers a new {@link MapperFactory} that can be used to create value mappers based on the generic type of the config key.
+     */
+    public static void registerValueMapperFactory(String modid, MapperFactory<?> factory) {
+        if (!Objects.equals(modid, ModLoadingContext.get().getActiveNamespace())) {
+            LibX.logger.error("Wrong modid for value mapper factory, expected " + ModLoadingContext.get().getActiveNamespace() + " got " + modid);
+        }
+        ModMappers.get(modid).registerValueMapperFactory(factory);
     }
     
     /**

--- a/src/main/java/org/moddingx/libx/config/mapper/MapperFactory.java
+++ b/src/main/java/org/moddingx/libx/config/mapper/MapperFactory.java
@@ -14,7 +14,7 @@ public interface MapperFactory<T> {
     Class<T> type();
 
     /**
-     * Creates a new {@link ValueMapper} from the give {@link Context}.
+     * Creates a new {@link ValueMapper} from the given {@link Context}.
      */
     @Nullable
     ValueMapper<T, ?> create(Context ctx);

--- a/src/main/java/org/moddingx/libx/config/mapper/MapperFactory.java
+++ b/src/main/java/org/moddingx/libx/config/mapper/MapperFactory.java
@@ -1,0 +1,35 @@
+package org.moddingx.libx.config.mapper;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.Type;
+
+/**
+ * A factory that creates a {@link ValueMapper} by the generic type of a config key.
+ */
+public interface MapperFactory<T> {
+
+    /**
+     * The base class for which this factory creates mappers.
+     */
+    Class<T> type();
+
+    /**
+     * Creates a new {@link ValueMapper} from the give {@link Context}.
+     */
+    @Nullable
+    ValueMapper<T, ?> create(Context ctx);
+    
+    interface Context {
+
+        /**
+         * The generic type of the config key.
+         */
+        Type getGenericType();
+
+        /**
+         * Wraps a {@link GenericValueMapper} into a regular {@link ValueMapper} given a mapper for
+         * the generic element type.
+         */
+        <T, C> ValueMapper<T, ?> wrap(GenericValueMapper<T, ?, C> mapper, ValueMapper<C, ?> child);
+    }
+}

--- a/src/main/java/org/moddingx/libx/impl/config/gui/screen/content/ResourceListContent.java
+++ b/src/main/java/org/moddingx/libx/impl/config/gui/screen/content/ResourceListContent.java
@@ -217,21 +217,21 @@ public class ResourceListContent implements ConfigScreenContent<ResourceList> {
 
         this.entryWidgets.set(idx, new EntryWidgets(typeWidget, modeWidget, widget));
 
-        ListContent.addControlButton(consumer, padding + 339, y, Component.literal("⬆"), idx > 0, () -> {
-            ListContent.move(this.list, idx, idx - 1);
-            ListContent.move(this.entryWidgets, idx, idx - 1);
+        CollectionContent.addControlButton(consumer, padding + 339, y, Component.literal("⬆"), idx > 0, () -> {
+            CollectionContent.move(this.list, idx, idx - 1);
+            CollectionContent.move(this.entryWidgets, idx, idx - 1);
             this.update();
             manager.rebuild();
         });
 
-        ListContent.addControlButton(consumer, padding + 362, y, Component.literal("⬇"), idx < this.list.size() - 1, () -> {
-            ListContent.move(this.list, idx, idx + 1);
-            ListContent.move(this.entryWidgets, idx, idx + 1);
+        CollectionContent.addControlButton(consumer, padding + 362, y, Component.literal("⬇"), idx < this.list.size() - 1, () -> {
+            CollectionContent.move(this.list, idx, idx + 1);
+            CollectionContent.move(this.entryWidgets, idx, idx + 1);
             this.update();
             manager.rebuild();
         });
 
-        ListContent.addControlButton(consumer, padding + 385, y, Component.literal("✖").withStyle(ChatFormatting.RED), true, () -> {
+        CollectionContent.addControlButton(consumer, padding + 385, y, Component.literal("✖").withStyle(ChatFormatting.RED), true, () -> {
             this.list.remove(idx);
             this.entryWidgets.remove(idx);
             this.update();

--- a/src/main/java/org/moddingx/libx/impl/config/gui/screen/content/component/ComponentContent.java
+++ b/src/main/java/org/moddingx/libx/impl/config/gui/screen/content/component/ComponentContent.java
@@ -12,7 +12,7 @@ import org.moddingx.libx.config.gui.ConfigScreenContent;
 import org.moddingx.libx.config.gui.EditorOps;
 import org.moddingx.libx.config.gui.WidgetProperties;
 import org.moddingx.libx.impl.config.gui.EditorHelper;
-import org.moddingx.libx.impl.config.gui.screen.content.ListContent;
+import org.moddingx.libx.impl.config.gui.screen.content.CollectionContent;
 import org.moddingx.libx.impl.config.gui.screen.content.component.type.KeybindComponentType;
 import org.moddingx.libx.impl.config.gui.screen.content.component.type.TextComponentType;
 import org.moddingx.libx.impl.config.gui.screen.content.component.type.TranslationComponentType;
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 public class ComponentContent implements ConfigScreenContent<Component> {
 
@@ -126,7 +127,7 @@ public class ComponentContent implements ConfigScreenContent<Component> {
         this.underlinedEditor = ConfigEditor.toggle(List.of(StyleSetting.INHERIT, StyleSetting.TRUE, StyleSetting.FALSE), s -> Component.translatable("libx.config.gui.component.underlined", Component.translatable("libx.config.gui.component.style_setting." + s.value)));
         this.strikethroughEditor = ConfigEditor.toggle(List.of(StyleSetting.INHERIT, StyleSetting.TRUE, StyleSetting.FALSE), s -> Component.translatable("libx.config.gui.component.strikethrough", Component.translatable("libx.config.gui.component.style_setting." + s.value)));
         this.obfuscatedEditor = ConfigEditor.toggle(List.of(StyleSetting.INHERIT, StyleSetting.TRUE, StyleSetting.FALSE), s -> Component.translatable("libx.config.gui.component.obfuscated", Component.translatable("libx.config.gui.component.style_setting." + s.value)));
-        this.siblingEditor = ConfigEditor.custom(List.of(), l -> new ListContent<>(l, ConfigEditor.custom(Component.empty(), ComponentContent::new)) {
+        this.siblingEditor = ConfigEditor.custom(List.of(), l -> new CollectionContent<>(l, ConfigEditor.custom(Component.empty(), ComponentContent::new), Function.identity(), true) {
 
             @Override
             public Component message() {

--- a/src/main/java/org/moddingx/libx/impl/config/gui/screen/content/component/type/TranslationComponentType.java
+++ b/src/main/java/org/moddingx/libx/impl/config/gui/screen/content/component/type/TranslationComponentType.java
@@ -9,7 +9,7 @@ import org.moddingx.libx.config.gui.ConfigEditor;
 import org.moddingx.libx.config.gui.ConfigScreenContent;
 import org.moddingx.libx.config.gui.WidgetProperties;
 import org.moddingx.libx.impl.config.gui.EditorHelper;
-import org.moddingx.libx.impl.config.gui.screen.content.ListContent;
+import org.moddingx.libx.impl.config.gui.screen.content.CollectionContent;
 import org.moddingx.libx.impl.config.gui.screen.content.component.ComponentContent;
 import org.moddingx.libx.impl.config.gui.screen.content.component.ComponentType;
 
@@ -20,6 +20,7 @@ import java.util.Formatter;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 public class TranslationComponentType implements ComponentType {
 
@@ -36,7 +37,7 @@ public class TranslationComponentType implements ComponentType {
 
     public TranslationComponentType() {
         this.editor = ConfigEditor.input();
-        this.argEditor = ConfigEditor.custom(List.of(), l -> new ListContent<>(l, ConfigEditor.custom(Component.empty(), ComponentContent::new)) {
+        this.argEditor = ConfigEditor.custom(List.of(), l -> new CollectionContent<>(l, ConfigEditor.custom(Component.empty(), ComponentContent::new), Function.identity(), true) {
 
             @Override
             public Component message() {

--- a/src/main/java/org/moddingx/libx/impl/config/mappers/generic/ListValueMapper.java
+++ b/src/main/java/org/moddingx/libx/impl/config/mappers/generic/ListValueMapper.java
@@ -11,10 +11,11 @@ import org.moddingx.libx.config.gui.ConfigEditor;
 import org.moddingx.libx.config.mapper.GenericValueMapper;
 import org.moddingx.libx.config.mapper.ValueMapper;
 import org.moddingx.libx.config.validator.ValidatorInfo;
-import org.moddingx.libx.impl.config.gui.screen.content.ListContent;
+import org.moddingx.libx.impl.config.gui.screen.content.CollectionContent;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 public class ListValueMapper<T> implements GenericValueMapper<List<T>, JsonArray, T> {
 
@@ -103,6 +104,6 @@ public class ListValueMapper<T> implements GenericValueMapper<List<T>, JsonArray
     @Override
     @OnlyIn(Dist.CLIENT)
     public ConfigEditor<List<T>> createEditor(ValueMapper<T, JsonElement> mapper, ValidatorInfo<?> validator) {
-        return ConfigEditor.custom(List.of(), list -> new ListContent<>(list, mapper.createEditor(ValidatorInfo.empty())));
+        return ConfigEditor.custom(List.of(), list -> new CollectionContent<>(list, mapper.createEditor(ValidatorInfo.empty()), Function.identity(), true));
     }
 }

--- a/src/main/java/org/moddingx/libx/impl/config/mappers/generic/SetValueMapper.java
+++ b/src/main/java/org/moddingx/libx/impl/config/mappers/generic/SetValueMapper.java
@@ -1,0 +1,125 @@
+package org.moddingx.libx.impl.config.mappers.generic;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import org.moddingx.libx.config.correct.ConfigCorrection;
+import org.moddingx.libx.config.gui.ConfigEditor;
+import org.moddingx.libx.config.mapper.GenericValueMapper;
+import org.moddingx.libx.config.mapper.ValueMapper;
+import org.moddingx.libx.config.validator.ValidatorInfo;
+import org.moddingx.libx.impl.config.gui.screen.content.CollectionContent;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+public class SetValueMapper<T> implements GenericValueMapper<Set<T>, JsonArray, T> {
+
+    public static final SetValueMapper<?> INSTANCE = new SetValueMapper<>();
+    
+    private static final Comparator<Object> COMPARATOR = (o1, o2) -> {
+        try {
+            if (o1 instanceof Comparable<?> cmp && (o1.getClass().isAssignableFrom(o2.getClass()) || o2.getClass().isAssignableFrom(o1.getClass()))) {
+                //noinspection unchecked
+                return ((Comparable<Object>) cmp).compareTo(o2);
+            }
+        } catch (Exception | NoClassDefFoundError e) {
+            //
+        }
+        return o1.toString().compareTo(o2.toString());
+    };
+
+    private SetValueMapper() {
+        
+    }
+    
+    @Override
+    public Class<Set<T>> type() {
+        //noinspection unchecked
+        return (Class<Set<T>>) (Class<?>) Set.class;
+    }
+
+    @Override
+    public Class<JsonArray> element() {
+        return JsonArray.class;
+    }
+
+    @Override
+    public int getGenericElementPosition() {
+        return 0;
+    }
+
+    @Override
+    public Set<T> fromJson(JsonArray json, ValueMapper<T, JsonElement> mapper) {
+        ImmutableSet.Builder<T> builder = ImmutableSet.builder();
+        for (int i = 0; i < json.size(); i++) {
+            JsonElement element = json.get(i);
+            builder.add(mapper.fromJson(element));
+        }
+        return builder.build();
+    }
+
+    @Override
+    public JsonArray toJson(Set<T> value, ValueMapper<T, JsonElement> mapper) {
+        JsonArray array = new JsonArray();
+        for (T element : this.getSortedElements(value)) {
+            array.add(mapper.toJson(element));
+        }
+        return array;
+    }
+
+    @Override
+    public Set<T> fromNetwork(FriendlyByteBuf buffer, ValueMapper<T, JsonElement> mapper) {
+        int size = buffer.readVarInt();
+        ImmutableSet.Builder<T> builder = ImmutableSet.builder();
+        for (int i = 0; i < size; i++) {
+            builder.add(mapper.fromNetwork(buffer));
+        }
+        return builder.build();
+    }
+
+    @Override
+    public void toNetwork(Set<T> value, FriendlyByteBuf buffer, ValueMapper<T, JsonElement> mapper) {
+        buffer.writeVarInt(value.size());
+        for (T element : value) {
+            mapper.toNetwork(element, buffer);
+        }
+    }
+
+    @Override
+    public Optional<Set<T>> correct(JsonElement json, ValueMapper<T, JsonElement> mapper, ConfigCorrection<Set<T>> correction) {
+        if (json.isJsonArray()) {
+            // Keep everything that can load in the set
+            ImmutableSet.Builder<T> set = ImmutableSet.builder();
+            for (int i = 0; i < json.getAsJsonArray().size(); i++) {
+                correction.tryCorrect(json.getAsJsonArray().get(i), mapper, value -> Optional.empty()).ifPresent(set::add);
+            }
+            Set<T> result = set.build();
+            if (result.isEmpty() && json.getAsJsonArray().size() > 0) {
+                // Nothing matched. Might be better to return the default value here
+                return Optional.empty();
+            } else {
+                return Optional.of(result);
+            }
+        } else {
+            // Maybe someone forgot to add a list for a single item.
+            // We just try to pass the entire json to the child mapper.
+            return correction.tryCorrect(json, mapper, ConfigCorrection.check(value -> value.size() == 1, value -> value.iterator().next())).map(Set::of);
+        }
+    }
+
+    @Override
+    @OnlyIn(Dist.CLIENT)
+    public ConfigEditor<Set<T>> createEditor(ValueMapper<T, JsonElement> mapper, ValidatorInfo<?> validator) {
+        return ConfigEditor.custom(Set.of(), set -> new CollectionContent<>(this.getSortedElements(set), mapper.createEditor(ValidatorInfo.empty()), Set::copyOf, false));
+    }
+    
+    private List<T> getSortedElements(Set<T> set) {
+        return set.stream().sorted(COMPARATOR).toList();
+    }
+}

--- a/src/main/java/org/moddingx/libx/impl/config/mappers/special/RecordValueMapper.java
+++ b/src/main/java/org/moddingx/libx/impl/config/mappers/special/RecordValueMapper.java
@@ -40,7 +40,7 @@ public class RecordValueMapper<T extends Record> implements ValueMapper<T, JsonO
         ImmutableList.Builder<EntryData> entries = ImmutableList.builder();
         for (int i = 0; i < parts.length; i++) {
             types[i] = parts[i].getType();
-            TypesafeMapper mapper = new TypesafeMapper(mapperFunc.apply(parts[i].getGenericType()));
+            TypesafeMapper mapper = TypesafeMapper.of(mapperFunc.apply(parts[i].getGenericType()));
             ConfiguredValidator<?, ?> validator = ConfiguredValidator.create(modid, parts[i]);
             entries.add(new EntryData(mapper, validator));
         }

--- a/src/main/java/org/moddingx/libx/impl/config/wrapper/TypesafeMapper.java
+++ b/src/main/java/org/moddingx/libx/impl/config/wrapper/TypesafeMapper.java
@@ -6,9 +6,17 @@ import org.moddingx.libx.config.mapper.ValueMapper;
 
 public class TypesafeMapper extends JsonTypesafeMapper<Object> {
     
-    public TypesafeMapper(ValueMapper<?, ?> mapper) {
+    private TypesafeMapper(ValueMapper<?, ?> mapper) {
         //noinspection unchecked
         super((ValueMapper<Object, ?>) mapper);
+    }
+    
+    public static TypesafeMapper of(ValueMapper<?, ?> mapper) {
+        if (mapper instanceof TypesafeMapper tm) {
+            return tm;
+        } else {
+            return new TypesafeMapper(mapper);
+        }
     }
 
     @Override

--- a/src/main/java/org/moddingx/libx/impl/registration/tracking/TrackingData.java
+++ b/src/main/java/org/moddingx/libx/impl/registration/tracking/TrackingData.java
@@ -155,12 +155,12 @@ public final class TrackingData<T> {
         }
     }
 
-    private static record TrackedStaticField(ResourceLocation id, Field field) {}
-    private static record TrackedInstanceField(ResourceLocation id, Field field, WeakReference<Object> instance) {}
-    private static record TrackedInstanceAction<T>(ResourceLocation id, WeakReference<Object> instance, Consumer<T> action) {}
+    private record TrackedStaticField(ResourceLocation id, Field field) {}
+    private record TrackedInstanceField(ResourceLocation id, Field field, WeakReference<Object> instance) {}
+    private record TrackedInstanceAction<T>(ResourceLocation id, WeakReference<Object> instance, Consumer<T> action) {}
     
     // Provide key with weak reference that allows hashing on fields and their instance
-    private static record TrackedFieldKey(Field field, @Nullable WeakReference<Object> instance, int instanceHash) {
+    private record TrackedFieldKey(Field field, @Nullable WeakReference<Object> instance, int instanceHash) {
         
         public static TrackedFieldKey create(Field field, @Nullable Object instance) {
             return new TrackedFieldKey(field, instance == null ? null : new WeakReference<>(instance), System.identityHashCode(instance));

--- a/src/main/java/org/moddingx/libx/network/NetworkX.java
+++ b/src/main/java/org/moddingx/libx/network/NetworkX.java
@@ -166,7 +166,7 @@ public abstract class NetworkX {
      * @param client The behaviour for the client
      * @param server The behaviour for the dedicated server
      */
-    public static record Protocol(String version, ProtocolSide client, ProtocolSide server) {
+    public record Protocol(String version, ProtocolSide client, ProtocolSide server) {
 
         /**
          * Creates a new protocol with the given version, that is required on both sides.

--- a/src/main/java/org/moddingx/libx/network/PacketHandler.java
+++ b/src/main/java/org/moddingx/libx/network/PacketHandler.java
@@ -14,19 +14,19 @@ public interface PacketHandler<T> {
     /**
      * The target thread, this handler should run on.
      */
-    public Target target();
+    Target target();
 
     /**
      * Handles the given message.
      * 
      * @return Whether the message was handled. This is ignored on the {@link Target#MAIN_THREAD main thread} target.
      */
-    public boolean handle(T msg, Supplier<NetworkEvent.Context> ctx);
+    boolean handle(T msg, Supplier<NetworkEvent.Context> ctx);
 
     /**
      * A thread target for a {@link PacketHandler}.
      */
-    public enum Target {
+    enum Target {
 
         /**
          * The main thread, where the game logic happens.

--- a/src/main/java/org/moddingx/libx/registration/Registerable.java
+++ b/src/main/java/org/moddingx/libx/registration/Registerable.java
@@ -115,11 +115,11 @@ public interface Registerable {
         /**
          * Adds a registry tracking action with the same registry name as the current object.
          */
-        public <T> void run(IForgeRegistry<T> registry, Consumer<T> action);
+        <T> void run(IForgeRegistry<T> registry, Consumer<T> action);
         
         /**
          * Adds a registry tracking action with the same registry name as the current object with a given suffix.
          */
-        public <T> void runNamed(IForgeRegistry<T> registry, String name, Consumer<T> action);
+        <T> void runNamed(IForgeRegistry<T> registry, String name, Consumer<T> action);
     }
 }

--- a/src/main/java/org/moddingx/libx/registration/RegistrationBuilder.java
+++ b/src/main/java/org/moddingx/libx/registration/RegistrationBuilder.java
@@ -48,5 +48,5 @@ public class RegistrationBuilder {
         return new Result(this.tracking, List.copyOf(this.conditions), List.copyOf(this.transformers));
     }
     
-    public static record Result(boolean tracking, List<RegistryCondition> conditions, List<RegistryTransformer> transformers) {}
+    public record Result(boolean tracking, List<RegistryCondition> conditions, List<RegistryTransformer> transformers) {}
 }


### PR DESCRIPTION
Adds value mapper factories. These can create a `ValueMapper` dynamically based on the generic type of a field. This allows for example to have `Maps` with keys that are not `String` or `TagKey`s that have their registry key set by their generic class.

Also adds a value mapper for sets. 