### PR TITLE
Expose ModXRegistration in RegistrationContext

### DIFF
--- a/src/main/java/org/moddingx/libx/impl/registration/RegistrationDispatcher.java
+++ b/src/main/java/org/moddingx/libx/impl/registration/RegistrationDispatcher.java
@@ -77,7 +77,7 @@ public class RegistrationDispatcher {
     
     public <T> void registerMulti(@Nullable ResourceKey<? extends Registry<T>> registry, String id, MultiRegisterable<T> value) {
         synchronized (this.LOCK) {
-            ResourceLocation rl = new ResourceLocation(this.mod.modid, id);
+            ResourceLocation rl = this.mod.resource(id);
             @Nullable
             ResourceKey<T> resourceKey = registry == null ? null : ResourceKey.create(registry, rl);
             RegistrationContext ctx = new RegistrationContext(this.mod, this.mod.resource(id), resourceKey);

--- a/src/main/java/org/moddingx/libx/mod/ModXRegistration.java
+++ b/src/main/java/org/moddingx/libx/mod/ModXRegistration.java
@@ -68,7 +68,7 @@ public abstract class ModXRegistration extends ModX {
 
         RegistrationBuilder builder = new RegistrationBuilder();
         this.initRegistration(builder);
-        this.dispatcher = new RegistrationDispatcher(this.modid, builder.build());
+        this.dispatcher = new RegistrationDispatcher(this, builder.build());
         ModInternal.get(this).initRegistration(this.dispatcher);
         
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this.dispatcher::registerBy);

--- a/src/main/java/org/moddingx/libx/registration/RegistrationContext.java
+++ b/src/main/java/org/moddingx/libx/registration/RegistrationContext.java
@@ -3,6 +3,7 @@ package org.moddingx.libx.registration;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import org.moddingx.libx.mod.ModXRegistration;
 
 import javax.annotation.Nullable;
 import java.util.Objects;
@@ -14,17 +15,26 @@ import java.util.Optional;
  */
 public sealed class RegistrationContext permits SetupContext {
 
+    private final ModXRegistration mod;
     private final ResourceLocation id;
     private final Optional<ResourceKey<?>> key;
     private final Optional<ResourceKey<? extends Registry<?>>> registry;
     
-    public RegistrationContext(ResourceLocation id, @Nullable ResourceKey<?> key) {
+    public RegistrationContext(ModXRegistration mod, ResourceLocation id, @Nullable ResourceKey<?> key) {
+        this.mod = mod;
         this.id = id;
         this.key = Optional.ofNullable(key);
         this.registry = this.key.map(ResourceKey::registry).map(ResourceKey::createRegistryKey);
         if (this.key.isPresent() && !Objects.equals(this.id, this.key.get().location())) {
             throw new IllegalArgumentException("Id does not match resource key: " + id + " " + key);
         }
+    }
+    
+    /**
+     * Gets the mod to which object belongs.
+     */
+    public ModXRegistration mod() {
+        return this.mod;
     }
 
     /**

--- a/src/main/java/org/moddingx/libx/registration/SetupContext.java
+++ b/src/main/java/org/moddingx/libx/registration/SetupContext.java
@@ -2,6 +2,7 @@ package org.moddingx.libx.registration;
 
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import org.moddingx.libx.mod.ModXRegistration;
 
 import javax.annotation.Nullable;
 import java.util.function.Consumer;
@@ -14,11 +15,11 @@ public final class SetupContext extends RegistrationContext {
     private final Consumer<Runnable> enqueue;
 
     public SetupContext(RegistrationContext ctx, Consumer<Runnable> enqueue) {
-        this(ctx.id(), ctx.key().orElse(null), enqueue);
+        this(ctx.mod(), ctx.id(), ctx.key().orElse(null), enqueue);
     }
     
-    public SetupContext(ResourceLocation id, @Nullable ResourceKey<?> key, Consumer<Runnable> enqueue) {
-        super(id, key);
+    public SetupContext(ModXRegistration mod, ResourceLocation id, @Nullable ResourceKey<?> key, Consumer<Runnable> enqueue) {
+        super(mod, id, key);
         this.enqueue = enqueue;
     }
 


### PR DESCRIPTION
This allows classes in libraries to create holders inside their `registerAdditional` method without hardcoding the mod instance to use.