### PR TITLE
Add ICondition support in ObjectCraftingBuilder

### DIFF
--- a/src/main/java/org/moddingx/libx/datagen/provider/recipe/crafting/CraftingExtension.java
+++ b/src/main/java/org/moddingx/libx/datagen/provider/recipe/crafting/CraftingExtension.java
@@ -17,7 +17,7 @@ public interface CraftingExtension extends RecipeExtension {
     /**
      * Adds a new shaped recipe based on the input objects. The input objects must
      * be built like this:
-     * <p>
+     *<p>
      * (A sub list means that <b>one</b> of its elements can be used.)
      *
      * <ul>
@@ -48,11 +48,12 @@ public interface CraftingExtension extends RecipeExtension {
     /**
      * Adds a new shapeless recipe based on the input objects. The input objects must
      * be built like this:
-     *
+     * <p>
      * (A sub list means that <b>one</b> of its elements can be used.)
      *
      * <ul>
      *     <li>Optional: A {@link ResourceLocation} that serves as the recipe id.</li>
+     *     <li>Optional: A {@link RecipeCategory}. Defaults to {@link RecipeCategory#MISC}</li>
      *     <ul>
      *         <li>An {@link ItemLike} for the output, optionally followed by an {@link Integer} for the amount.</li>
      *         <li>An {@link ItemStack} whose item and count form the output.</li>

--- a/src/main/java/org/moddingx/libx/datagen/provider/recipe/crafting/CraftingExtension.java
+++ b/src/main/java/org/moddingx/libx/datagen/provider/recipe/crafting/CraftingExtension.java
@@ -17,25 +17,26 @@ public interface CraftingExtension extends RecipeExtension {
     /**
      * Adds a new shaped recipe based on the input objects. The input objects must
      * be built like this:
-     * 
+     * <p>
      * (A sub list means that <b>one</b> of its elements can be used.)
-     * 
+     *
      * <ul>
      *     <li>Optional: A {@link ResourceLocation} that serves as the recipe id.</li>
      *     <li>Optional: A {@link RecipeCategory}. Defaults to {@link RecipeCategory#MISC}</li>
      *     <ul>
-     *         <li>An {@link ItemLike} for the output optionally followed by an {@link Integer} for the amount.</li>
-     *         <li>An {@link ItemStack} that is used to determine the output item and count.</li>
+     *         <li>An {@link ItemLike} for the output, optionally followed by an {@link Integer} for the amount.</li>
+     *         <li>An {@link ItemStack} whose item and count form the output.</li>
      *     </ul>
-     *     <li>A set of strings which are the pattern lines for the recipe.</li>
-     *     <li>The rest of the input must be a {@link Character} followed by an ingredient identifier repeated for each key from the pattern lines.</li>
+     *     <li>One or more {@code String}s that form the pattern lines of the recipe.</li>
+     *     <li>For every non-space character used in the pattern: the {@link Character} itself followed by the ingredient identifier that defines that key.</li>
+     *     <li>Optional: One or more {@code ICondition}s as conditions for the recipe.</li>
      * </ul>
-     * 
+     *
      * An ingredient identifier is one of the following:
-     * 
+     *
      * <ul>
      *     <li>An {@link ItemLike}</li>
-     *     <li>An {@link TagKey TagKey&lt;Item&gt;}</li>
+     *     <li>A {@link TagKey TagKey&lt;Item&gt;}</li>
      *     <li>An {@link Ingredient}</li>
      *     <li>A list of the ones above.</li>
      * </ul>
@@ -53,17 +54,18 @@ public interface CraftingExtension extends RecipeExtension {
      * <ul>
      *     <li>Optional: A {@link ResourceLocation} that serves as the recipe id.</li>
      *     <ul>
-     *         <li>An {@link ItemLike} for the output optionally followed by an {@link Integer} for the amount.</li>
-     *         <li>An {@link ItemStack} that is used to determine the output item and count.</li>
+     *         <li>An {@link ItemLike} for the output, optionally followed by an {@link Integer} for the amount.</li>
+     *         <li>An {@link ItemStack} whose item and count form the output.</li>
      *     </ul>
-     *     <li>The rest of the input must be ingredient identifiers which set the required items.</li>
+     *     <li>One or more ingredient identifiers that make up the recipe inputs.</li>
+     *     <li>Optional: One or more {@code ICondition}s as conditions for the recipe.</li>
      * </ul>
      *
      * An ingredient identifier is one of the following:
      *
      * <ul>
      *     <li>An {@link ItemLike}</li>
-     *     <li>An {@link TagKey TagKey&lt;Item&gt;}</li>
+     *     <li>A {@link TagKey TagKey&lt;Item&gt;}</li>
      *     <li>An {@link Ingredient}</li>
      *     <li>A list of the ones above.</li>
      * </ul>

--- a/src/main/java/org/moddingx/libx/impl/datagen/recipe/ObjectCraftingBuilder.java
+++ b/src/main/java/org/moddingx/libx/impl/datagen/recipe/ObjectCraftingBuilder.java
@@ -3,6 +3,7 @@ package org.moddingx.libx.impl.datagen.recipe;
 import net.minecraft.advancements.Criterion;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.recipes.RecipeCategory;
+import net.minecraft.data.recipes.RecipeOutput;
 import net.minecraft.data.recipes.ShapedRecipeBuilder;
 import net.minecraft.data.recipes.ShapelessRecipeBuilder;
 import net.minecraft.resources.ResourceLocation;
@@ -11,12 +12,14 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.ItemLike;
+import net.neoforged.neoforge.common.conditions.ICondition;
 import net.neoforged.neoforge.common.crafting.CompoundIngredient;
 import org.moddingx.libx.datagen.provider.recipe.RecipeExtension;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiConsumer;
@@ -35,7 +38,12 @@ public class ObjectCraftingBuilder {
             builder.pattern(line);
         }
         addShapedIngredients(ext, builder, reader);
-        builder.save(ext.output(), id);
+        RecipeOutput recipeOutput = ext.output();
+        List<ICondition> conditions = consumeConditions(reader);
+        if (!conditions.isEmpty()) {
+            recipeOutput = recipeOutput.withConditions(conditions.toArray(ICondition[]::new));
+        }
+        builder.save(recipeOutput, id);
     }
 
     public static void buildShapeless(RecipeExtension ext, Object[] objects) {
@@ -46,7 +54,12 @@ public class ObjectCraftingBuilder {
         if (id == null) id = ext.provider().loc(output.getItem());
         ShapelessRecipeBuilder builder = ShapelessRecipeBuilder.shapeless(recipeCategory, output);
         addShapelessIngredients(ext, builder, reader);
-        builder.save(ext.output(), id);
+        RecipeOutput recipeOutput = ext.output();
+        List<ICondition> conditions = consumeConditions(reader);
+        if (!conditions.isEmpty()) {
+            recipeOutput = recipeOutput.withConditions(conditions.toArray(ICondition[]::new));
+        }
+        builder.save(recipeOutput, id);
     }
 
     @Nullable
@@ -57,6 +70,25 @@ public class ObjectCraftingBuilder {
     @Nonnull
     private static RecipeCategory getRecipeCategory(ObjectReader reader) {
         return reader.optConsume(RecipeCategory.class).orElse(RecipeCategory.MISC);
+    }
+
+    @Nonnull
+    private static List<ICondition> consumeConditions(ObjectReader reader) {
+        List<ICondition> conditions = new ArrayList<>();
+        while (reader.hasNext()) {
+            Object next = reader.peek();
+            if (next instanceof ICondition condition) {
+                reader.consume();
+                conditions.add(condition);
+            } else if (next instanceof ICondition[] conditionArray) {
+                reader.consume();
+                conditions.addAll(List.of(conditionArray));
+            } else {
+                break;
+            }
+        }
+
+        return conditions;
     }
 
     private static void addShapedIngredients(RecipeExtension ext, ShapedRecipeBuilder builder, ObjectReader reader) {
@@ -77,6 +109,11 @@ public class ObjectCraftingBuilder {
     private static void addShapelessIngredients(RecipeExtension ext, ShapelessRecipeBuilder builder, ObjectReader reader) {
         int nextId = 0;
         while (reader.hasNext()) {
+            Object peek = reader.peek();
+            if (peek instanceof ICondition || peek instanceof ICondition[]) {
+                break;
+            }
+
             Ingredient ingredient = getIngredient(reader);
             builder.requires(ingredient);
             nextId = addCriteriaToBuilder(builder::unlockedBy, ext.criteria(ingredient), nextId);
@@ -118,7 +155,7 @@ public class ObjectCraftingBuilder {
         //noinspection unchecked
         return Ingredient.of((TagKey<Item>) key);
     }
-    
+
     @SafeVarargs
     private static <T> Optional<T> first(Supplier<Optional<T>>... values) {
         for (Supplier<Optional<T>> value : values) {
@@ -215,7 +252,7 @@ public class ObjectCraftingBuilder {
                 }
             }
         }
-        
+
         @Nonnull
         @SuppressWarnings("UnusedReturnValue")
         public Object consume() {


### PR DESCRIPTION
This pull request adds a new feature to the `ObjectCraftingBuilder`. You can now add any `ICondition` object to the `Object` array in `buildShaped` and `buildShapeless` to apply certain conditions to this recipe. This is pretty useful if you only have a few recipes with conditions and you don't want to add a new `RecipeProviderBase` instance with `RecipeProviderBase#conditions` set for these few recipes. You can just use it like this:
```java
this.shapeless(this.output(AIOTRegistry.redstoneAiot), RecipeCategory.TOOLS, AIOTRegistry.redstoneAiot, ModItems.redstoneSword, ModItems.redstonePickaxe, ModItems.redstoneAxe, ModItems.redstoneShovel, ModItems.redstoneHoe, new ModLoadedCondition(CompatHelper.MOREVANILLATOOLS), new VanillaCondition());
```

