### PR TITLE
Make config navigation consistent (back to selector)

### DIFF
--- a/src/main/java/org/moddingx/libx/impl/config/gui/ModConfigGuiAdapter.java
+++ b/src/main/java/org/moddingx/libx/impl/config/gui/ModConfigGuiAdapter.java
@@ -9,10 +9,9 @@ import org.moddingx.libx.impl.config.gui.screen.ConfigScreenManager;
 import org.moddingx.libx.impl.config.gui.screen.ConfigSelectScreen;
 import org.moddingx.libx.impl.config.gui.screen.RootConfigScreen;
 
-import javax.annotation.Nullable;
 import java.util.Comparator;
 import java.util.List;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 public class ModConfigGuiAdapter {
     
@@ -41,14 +40,14 @@ public class ModConfigGuiAdapter {
         if (configs.isEmpty()) {
             return modListScreen;
         } else if (configs.size() == 1) {
-            return this.factory(modListScreen.getMinecraft(), modListScreen).apply(configs.get(0));
+            return this.factory(modListScreen.getMinecraft()).apply(configs.getFirst(), modListScreen);
         } else {
-            return new ConfigSelectScreen(this.factory(modListScreen.getMinecraft(), modListScreen), configs, modListScreen);
+            return new ConfigSelectScreen(this.factory(modListScreen.getMinecraft()), configs, modListScreen);
         }
     }
     
-    private Function<ConfigImpl, Screen> factory(Minecraft minecraft, @Nullable Screen root) {
-        return config -> {
+    private BiFunction<ConfigImpl, Screen, Screen> factory(Minecraft minecraft) {
+        return (config, root) -> {
             ConfigDisplay display = config.createDisplay();
             ConfigScreenManager manager = new ConfigScreenManager(minecraft, root, display);
             // Must also push to the manager

--- a/src/main/java/org/moddingx/libx/impl/config/gui/screen/ConfigSelectScreen.java
+++ b/src/main/java/org/moddingx/libx/impl/config/gui/screen/ConfigSelectScreen.java
@@ -8,16 +8,16 @@ import org.lwjgl.glfw.GLFW;
 import org.moddingx.libx.impl.config.ConfigImpl;
 
 import java.util.List;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 public class ConfigSelectScreen extends ConfigBaseScreen {
 
-    private final Function<ConfigImpl, Screen> factory;
+    private final BiFunction<ConfigImpl, Screen, Screen> factory;
     private final List<ConfigImpl> configs;
     private final Screen root;
     
-    public ConfigSelectScreen(Function<ConfigImpl, Screen> factory, List<ConfigImpl> configs, Screen root) {
+    public ConfigSelectScreen(BiFunction<ConfigImpl, Screen, Screen> factory, List<ConfigImpl> configs, Screen root) {
         super(Component.translatable("libx.config.gui.selection.title"), null, false);
         this.factory = factory;
         this.configs = configs;
@@ -26,10 +26,19 @@ public class ConfigSelectScreen extends ConfigBaseScreen {
 
     @Override
     protected void buildGui(Consumer<AbstractWidget> consumer) {
+        Button back = Button.builder(Component.literal("\u2190 ").append(Component.translatable("libx.config.gui.back")), button -> this.mc.setScreen(this.root))
+                .pos(5, 5)
+                .size(52, 20)
+                .build();
+        this.addRenderableWidget(back);
+
         int y = 5;
         int buttonWidth = Math.min(200, this.contentWidth() - 10);
         for (ConfigImpl config : this.configs) {
-            Button button = Button.builder(Component.literal(config.id.getPath()), b -> this.mc.setScreen(this.factory.apply(config)))
+            Button button = Button.builder(Component.literal(config.id.getPath()), b -> {
+                        Screen configSelectScreen = this.factory.apply(config, this);
+                        this.mc.setScreen(configSelectScreen);
+                    })
                     .pos((this.contentWidth() - buttonWidth) / 2, y)
                     .size(buttonWidth, 20)
                     .build();

--- a/src/main/java/org/moddingx/libx/impl/config/gui/screen/RootConfigScreen.java
+++ b/src/main/java/org/moddingx/libx/impl/config/gui/screen/RootConfigScreen.java
@@ -48,7 +48,7 @@ public class RootConfigScreen extends ConfigScreen<ConfigKey> {
 
     private static BuiltEntry createEntry(ConfigKey key, ConfigScreen<ConfigKey> screen, @Nullable AbstractWidget old, int x, int y, int width, int height) {
         return new BuiltEntry(
-                Component.literal(key.path.get(key.path.size() - 1)),
+                Component.literal(key.path.getLast()),
                 key.comment.stream().map(Component::literal).collect(ImmutableList.toImmutableList()),
                 screen.display.createWidget(key, screen, old, x, y, width, height)
         );


### PR DESCRIPTION
Before, when you had multiple configs and edited one, you pressed the "Back" button and was back at the mod list screen. That was annoying if you wanted to edit multiple configs.

Now, you are redirected back to the config selector screen instead. This screen also got a "Back" button. 

