### PR TITLE
Fix crash for blocks that use copy block entity data function

### DIFF
--- a/src/main/java/org/moddingx/libx/impl/loot/CopyBlockEntityDataFunction.java
+++ b/src/main/java/org/moddingx/libx/impl/loot/CopyBlockEntityDataFunction.java
@@ -13,6 +13,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.storage.loot.LootContext;
 import net.minecraft.world.level.storage.loot.functions.LootItemConditionalFunction;
 import net.minecraft.world.level.storage.loot.functions.LootItemFunctionType;
@@ -22,6 +23,7 @@ import org.moddingx.libx.LibX;
 
 import javax.annotation.Nonnull;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 public class CopyBlockEntityDataFunction extends LootItemConditionalFunction {
@@ -65,6 +67,7 @@ public class CopyBlockEntityDataFunction extends LootItemConditionalFunction {
                         data = data.update(nbt -> nbt.put(tagName, tag.copy()));
                     }
                 }
+                data = data.update(nbt -> nbt.putString("id", Objects.requireNonNull(BlockEntityType.getKey(blockEntity.getType())).toString()));
                 return data;
             });
         }


### PR DESCRIPTION
If you have a block in your child of `BlockLootProviderBase` that registers it's loot table like this, Minecraft fails to encode the data because `id` is missing. That results in a crash when the game wants to save the players inventory for example.

```java
this.drops(ModBlocks.experienceCrystal, this.noSilk(), this.copyNBT("Xp"));
```

This PR makes sure to always add the block entity id to the item.