### PR TITLE
Add feature flag support to blocks and items

### DIFF
--- a/src/main/java/org/moddingx/libx/base/BlockBase.java
+++ b/src/main/java/org/moddingx/libx/base/BlockBase.java
@@ -1,6 +1,7 @@
 package org.moddingx.libx.base;
 
 import net.minecraft.core.registries.Registries;
+import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -84,6 +85,11 @@ public class BlockBase extends Block implements Registerable, CreativeTabItemPro
         @Override
         public Stream<ItemStack> makeCreativeTabStacks() {
             return BlockBase.this.makeCreativeTabStacks();
+        }
+
+        @Override
+        public boolean isEnabled(@Nonnull FeatureFlagSet enabledFeatures) {
+            return this.getBlock().isEnabled(enabledFeatures);
         }
     }
 }

--- a/src/main/java/org/moddingx/libx/base/FluidBase.java
+++ b/src/main/java/org/moddingx/libx/base/FluidBase.java
@@ -2,6 +2,7 @@ package org.moddingx.libx.base;
 
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.item.BucketItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
@@ -30,6 +31,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.OverridingMethodsMustInvokeSuper;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
 /**
@@ -168,18 +170,20 @@ public class FluidBase implements ItemLike, Registerable {
         private BlockBehaviour.Properties blockProperties;
         private Item.Properties bucketItemProperties;
         private UnaryOperator<BaseFlowingFluid.Properties> fluidProperties;
+        private Supplier<Boolean> enabled;
         
         private Builder() {
             this.fluidTypeFactory = FluidType::new;
             this.sourceFluidFactory = BaseFlowingFluid.Source::new;
             this.flowingFluidFactory = BaseFlowingFluid.Flowing::new;
-            this.liquidBlockFactory = LiquidBlock::new;
-            this.bucketItemFactory = DefaultBucketItem::new;
+            this.liquidBlockFactory = this.defaultLiquidBlockFactory();
+            this.bucketItemFactory = this.defaultBucketItemFactory();
             
             this.fluidTypeProperties = FluidType.Properties.create();
             this.blockProperties = BlockBehaviour.Properties.ofFullCopy(Blocks.WATER);
             this.bucketItemProperties = new Item.Properties().craftRemainder(Items.BUCKET).stacksTo(1);
             this.fluidProperties = UnaryOperator.identity();
+            this.enabled = () -> true;
         }
 
         /**
@@ -277,6 +281,29 @@ public class FluidBase implements ItemLike, Registerable {
         public FluidBase.Builder fluidProperties(UnaryOperator<BaseFlowingFluid.Properties> fluidPropertiesOp) {
             this.fluidProperties = compose(this.fluidProperties, fluidPropertiesOp);
             return this;
+        }
+
+        public FluidBase.Builder isEnabled(Supplier<Boolean> enabled) {
+            this.enabled = enabled;
+            return this;
+        }
+
+        private BiFunction<? super FlowingFluid, ? super BlockBehaviour.Properties, ? extends LiquidBlock> defaultLiquidBlockFactory() {
+            return (FlowingFluid fluid, BlockBehaviour.Properties properties) -> new LiquidBlock(fluid, properties) {
+                @Override
+                public boolean isEnabled(@Nonnull FeatureFlagSet enabledFeatures) {
+                    return Builder.this.enabled.get();
+                }
+            };
+        }
+
+        private BiFunction<? super Fluid, ? super Item.Properties, ? extends BucketItem> defaultBucketItemFactory() {
+            return (Fluid content, Item.Properties properties) -> new  DefaultBucketItem(content, properties) {
+                @Override
+                public boolean isEnabled(@Nonnull FeatureFlagSet enabledFeatures) {
+                    return Builder.this.enabled.get();
+                }
+            };
         }
         
         private static <T> UnaryOperator<T> compose(UnaryOperator<T> a, UnaryOperator<T> b) {

--- a/src/main/java/org/moddingx/libx/impl/base/decoration/BlockDecorationType.java
+++ b/src/main/java/org/moddingx/libx/impl/base/decoration/BlockDecorationType.java
@@ -3,6 +3,7 @@ package org.moddingx.libx.impl.base.decoration;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -88,6 +89,11 @@ public class BlockDecorationType<T extends Block> extends BaseDecorationType<T> 
             int burnTime = this.parent.getBurnTime(stack, recipeType);
             if (burnTime < 0) return burnTime;
             return (int) Math.round(this.burnTimeModifier * burnTime);
+        }
+
+        @Override
+        public boolean isEnabled(@Nonnull FeatureFlagSet enabledFeatures) {
+            return this.parent.isEnabled(enabledFeatures);
         }
     }
 }

--- a/src/main/java/org/moddingx/libx/impl/base/decoration/blocks/DecoratedButton.java
+++ b/src/main/java/org/moddingx/libx/impl/base/decoration/blocks/DecoratedButton.java
@@ -2,6 +2,7 @@ package org.moddingx.libx.impl.base.decoration.blocks;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.ButtonBlock;
@@ -38,5 +39,10 @@ public class DecoratedButton extends ButtonBlock {
     @Override
     public int getLightEmission(@Nonnull BlockState state, @Nonnull BlockGetter world, @Nonnull BlockPos pos) {
         return this.parent.getLightEmission(state, world, pos);
+    }
+
+    @Override
+    public boolean isEnabled(@Nonnull FeatureFlagSet enabledFeatures) {
+        return this.parent.isEnabled(enabledFeatures);
     }
 }

--- a/src/main/java/org/moddingx/libx/impl/base/decoration/blocks/DecoratedDoorBlock.java
+++ b/src/main/java/org/moddingx/libx/impl/base/decoration/blocks/DecoratedDoorBlock.java
@@ -2,6 +2,7 @@ package org.moddingx.libx.impl.base.decoration.blocks;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.DoorBlock;
@@ -39,5 +40,10 @@ public class DecoratedDoorBlock extends DoorBlock implements Registerable {
     @Override
     public int getLightEmission(@Nonnull BlockState state, @Nonnull BlockGetter world, @Nonnull BlockPos pos) {
         return this.parent.getLightEmission(state, world, pos);
+    }
+
+    @Override
+    public boolean isEnabled(@Nonnull FeatureFlagSet enabledFeatures) {
+        return this.parent.isEnabled(enabledFeatures);
     }
 }

--- a/src/main/java/org/moddingx/libx/impl/base/decoration/blocks/DecoratedFenceBlock.java
+++ b/src/main/java/org/moddingx/libx/impl/base/decoration/blocks/DecoratedFenceBlock.java
@@ -2,6 +2,7 @@ package org.moddingx.libx.impl.base.decoration.blocks;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.FenceBlock;
@@ -38,5 +39,10 @@ public class DecoratedFenceBlock extends FenceBlock {
     @Override
     public int getLightEmission(@Nonnull BlockState state, @Nonnull BlockGetter world, @Nonnull BlockPos pos) {
         return this.parent.getLightEmission(state, world, pos);
+    }
+
+    @Override
+    public boolean isEnabled(@Nonnull FeatureFlagSet enabledFeatures) {
+        return this.parent.isEnabled(enabledFeatures);
     }
 }

--- a/src/main/java/org/moddingx/libx/impl/base/decoration/blocks/DecoratedFenceGateBlock.java
+++ b/src/main/java/org/moddingx/libx/impl/base/decoration/blocks/DecoratedFenceGateBlock.java
@@ -2,6 +2,7 @@ package org.moddingx.libx.impl.base.decoration.blocks;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.FenceGateBlock;
@@ -38,5 +39,10 @@ public class DecoratedFenceGateBlock extends FenceGateBlock {
     @Override
     public int getLightEmission(@Nonnull BlockState state, @Nonnull BlockGetter world, @Nonnull BlockPos pos) {
         return this.parent.getLightEmission(state, world, pos);
+    }
+
+    @Override
+    public boolean isEnabled(@Nonnull FeatureFlagSet enabledFeatures) {
+        return this.parent.isEnabled(enabledFeatures);
     }
 }

--- a/src/main/java/org/moddingx/libx/impl/base/decoration/blocks/DecoratedHangingSign.java
+++ b/src/main/java/org/moddingx/libx/impl/base/decoration/blocks/DecoratedHangingSign.java
@@ -5,6 +5,7 @@ import net.minecraft.client.renderer.blockentity.BlockEntityRenderers;
 import net.minecraft.client.renderer.blockentity.HangingSignRenderer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.item.HangingSignItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.CeilingHangingSignBlock;
@@ -47,7 +48,13 @@ public class DecoratedHangingSign implements Registerable, HangingSignAccess {
         this.wall = new Wall(this.parent, this::getBlockEntityType, this.parent.getMaterialProperties().woodType());
         //noinspection ConstantConditions
         this.beType = new BlockEntityType<>((pos, state) -> new Entity(this.getBlockEntityType(), pos, state), Set.of(this.ceiling, this.wall), null);
-        this.item = new HangingSignItem(this.ceiling, this.wall, new Item.Properties().stacksTo(16));
+        this.item = new HangingSignItem(this.ceiling, this.wall, new Item.Properties().stacksTo(16)) {
+
+            @Override
+            public boolean isEnabled(@Nonnull FeatureFlagSet enabledFeatures) {
+                return parent.isEnabled(enabledFeatures);
+            }
+        };
     }
 
     @Override
@@ -108,6 +115,11 @@ public class DecoratedHangingSign implements Registerable, HangingSignAccess {
         public BlockEntity newBlockEntity(@Nonnull BlockPos pos, @Nonnull BlockState state) {
             return this.beType.get().create(pos, state);
         }
+
+        @Override
+        public boolean isEnabled(@Nonnull FeatureFlagSet enabledFeatures) {
+            return this.parent.isEnabled(enabledFeatures);
+        }
     }
     
     public static class Wall extends WallHangingSignBlock {
@@ -126,6 +138,11 @@ public class DecoratedHangingSign implements Registerable, HangingSignAccess {
         @SuppressWarnings("NullableProblems")
         public BlockEntity newBlockEntity(@Nonnull BlockPos pos, @Nonnull BlockState state) {
             return this.beType.get().create(pos, state);
+        }
+
+        @Override
+        public boolean isEnabled(@Nonnull FeatureFlagSet enabledFeatures) {
+            return this.parent.isEnabled(enabledFeatures);
         }
     }
     

--- a/src/main/java/org/moddingx/libx/impl/base/decoration/blocks/DecoratedPressurePlate.java
+++ b/src/main/java/org/moddingx/libx/impl/base/decoration/blocks/DecoratedPressurePlate.java
@@ -2,6 +2,7 @@ package org.moddingx.libx.impl.base.decoration.blocks;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.PressurePlateBlock;
@@ -38,5 +39,10 @@ public class DecoratedPressurePlate extends PressurePlateBlock {
     @Override
     public int getLightEmission(@Nonnull BlockState state, @Nonnull BlockGetter world, @Nonnull BlockPos pos) {
         return this.parent.getLightEmission(state, world, pos);
+    }
+
+    @Override
+    public boolean isEnabled(@Nonnull FeatureFlagSet enabledFeatures) {
+        return this.parent.isEnabled(enabledFeatures);
     }
 }

--- a/src/main/java/org/moddingx/libx/impl/base/decoration/blocks/DecoratedSign.java
+++ b/src/main/java/org/moddingx/libx/impl/base/decoration/blocks/DecoratedSign.java
@@ -5,6 +5,7 @@ import net.minecraft.client.renderer.blockentity.BlockEntityRenderers;
 import net.minecraft.client.renderer.blockentity.SignRenderer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.SignItem;
 import net.minecraft.world.level.block.StandingSignBlock;
@@ -47,7 +48,12 @@ public class DecoratedSign implements Registerable, SignAccess {
         this.wall = new Wall(this.parent, this::getBlockEntityType, this.parent.getMaterialProperties().woodType());
         //noinspection ConstantConditions
         this.beType = new BlockEntityType<>((pos, state) -> new Entity(this.getBlockEntityType(), pos, state), Set.of(this.standing, this.wall), null);
-        this.item = new SignItem(new Item.Properties().stacksTo(16), this.standing, this.wall);
+        this.item = new SignItem(new Item.Properties().stacksTo(16), this.standing, this.wall) {
+            @Override
+            public boolean isEnabled(@Nonnull FeatureFlagSet enabledFeatures) {
+                return parent.isEnabled(enabledFeatures);
+            }
+        };
     }
 
     @Override
@@ -108,6 +114,11 @@ public class DecoratedSign implements Registerable, SignAccess {
         public BlockEntity newBlockEntity(@Nonnull BlockPos pos, @Nonnull BlockState state) {
             return this.beType.get().create(pos, state);
         }
+
+        @Override
+        public boolean isEnabled(@Nonnull FeatureFlagSet enabledFeatures) {
+            return this.parent.isEnabled(enabledFeatures);
+        }
     }
     
     public static class Wall extends WallSignBlock {
@@ -126,6 +137,11 @@ public class DecoratedSign implements Registerable, SignAccess {
         @SuppressWarnings("NullableProblems")
         public BlockEntity newBlockEntity(@Nonnull BlockPos pos, @Nonnull BlockState state) {
             return this.beType.get().create(pos, state);
+        }
+
+        @Override
+        public boolean isEnabled(@Nonnull FeatureFlagSet enabledFeatures) {
+            return this.parent.isEnabled(enabledFeatures);
         }
     }
     

--- a/src/main/java/org/moddingx/libx/impl/base/decoration/blocks/DecoratedSlabBlock.java
+++ b/src/main/java/org/moddingx/libx/impl/base/decoration/blocks/DecoratedSlabBlock.java
@@ -2,6 +2,7 @@ package org.moddingx.libx.impl.base.decoration.blocks;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.SlabBlock;
@@ -38,5 +39,10 @@ public class DecoratedSlabBlock extends SlabBlock {
     @Override
     public int getLightEmission(@Nonnull BlockState state, @Nonnull BlockGetter world, @Nonnull BlockPos pos) {
         return this.parent.getLightEmission(state, world, pos);
+    }
+
+    @Override
+    public boolean isEnabled(@Nonnull FeatureFlagSet enabledFeatures) {
+        return this.parent.isEnabled(enabledFeatures);
     }
 }

--- a/src/main/java/org/moddingx/libx/impl/base/decoration/blocks/DecoratedStairBlock.java
+++ b/src/main/java/org/moddingx/libx/impl/base/decoration/blocks/DecoratedStairBlock.java
@@ -2,6 +2,7 @@ package org.moddingx.libx.impl.base.decoration.blocks;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.StairBlock;
@@ -38,5 +39,10 @@ public class DecoratedStairBlock extends StairBlock {
     @Override
     public int getLightEmission(@Nonnull BlockState state, @Nonnull BlockGetter world, @Nonnull BlockPos pos) {
         return this.parent.getLightEmission(state, world, pos);
+    }
+
+    @Override
+    public boolean isEnabled(@Nonnull FeatureFlagSet enabledFeatures) {
+        return this.parent.isEnabled(enabledFeatures);
     }
 }

--- a/src/main/java/org/moddingx/libx/impl/base/decoration/blocks/DecoratedTrapdoorBlock.java
+++ b/src/main/java/org/moddingx/libx/impl/base/decoration/blocks/DecoratedTrapdoorBlock.java
@@ -2,6 +2,7 @@ package org.moddingx.libx.impl.base.decoration.blocks;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.TrapDoorBlock;
@@ -39,5 +40,10 @@ public class DecoratedTrapdoorBlock extends TrapDoorBlock implements Registerabl
     @Override
     public int getLightEmission(@Nonnull BlockState state, @Nonnull BlockGetter world, @Nonnull BlockPos pos) {
         return this.parent.getLightEmission(state, world, pos);
+    }
+
+    @Override
+    public boolean isEnabled(@Nonnull FeatureFlagSet enabledFeatures) {
+        return this.parent.isEnabled(enabledFeatures);
     }
 }

--- a/src/main/java/org/moddingx/libx/impl/base/decoration/blocks/DecoratedWallBlock.java
+++ b/src/main/java/org/moddingx/libx/impl/base/decoration/blocks/DecoratedWallBlock.java
@@ -2,6 +2,7 @@ package org.moddingx.libx.impl.base.decoration.blocks;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.WallBlock;
@@ -38,5 +39,10 @@ public class DecoratedWallBlock extends WallBlock {
     @Override
     public int getLightEmission(@Nonnull BlockState state, @Nonnull BlockGetter world, @Nonnull BlockPos pos) {
         return this.parent.getLightEmission(state, world, pos);
+    }
+
+    @Override
+    public boolean isEnabled(@Nonnull FeatureFlagSet enabledFeatures) {
+        return this.parent.isEnabled(enabledFeatures);
     }
 }

--- a/src/main/java/org/moddingx/libx/impl/base/decoration/blocks/DecoratedWoodBlock.java
+++ b/src/main/java/org/moddingx/libx/impl/base/decoration/blocks/DecoratedWoodBlock.java
@@ -2,6 +2,7 @@ package org.moddingx.libx.impl.base.decoration.blocks;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
@@ -60,5 +61,10 @@ public class DecoratedWoodBlock extends RotatedPillarBlock {
         } else {
             return super.getToolModifiedState(state, context, itemAbility, simulate);
         }
+    }
+
+    @Override
+    public boolean isEnabled(@Nonnull FeatureFlagSet enabledFeatures) {
+        return this.parent.isEnabled(enabledFeatures);
     }
 }


### PR DESCRIPTION
This PR redirects the `FeatureElement#isEnabled` state from parent items to their children, e.g. the `BlockBase` and their automatically added `item` will both be disabled instead of just the block. 
For the `FluidBase`, we only can disable the fluids block and the bucket item. To be able to edit the config in-game, we need to use a `Supplier<Boolean>` in the `FluidBase.Builder`.