### PR TITLE
Add tooltips to config widget editor

### DIFF
--- a/src/main/java/org/moddingx/libx/impl/config/gui/screen/RootConfigScreen.java
+++ b/src/main/java/org/moddingx/libx/impl/config/gui/screen/RootConfigScreen.java
@@ -3,6 +3,7 @@ package org.moddingx.libx.impl.config.gui.screen;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.network.chat.Component;
 import org.moddingx.libx.impl.config.ConfigImpl;
 import org.moddingx.libx.impl.config.ConfigKey;
@@ -47,10 +48,13 @@ public class RootConfigScreen extends ConfigScreen<ConfigKey> {
     }
 
     private static BuiltEntry createEntry(ConfigKey key, ConfigScreen<ConfigKey> screen, @Nullable AbstractWidget old, int x, int y, int width, int height) {
+        AbstractWidget widget = screen.display.createWidget(key, screen, old, x, y, width, height);
+        String configName = key.path.getLast();
+        widget.setTooltip(Tooltip.create(Component.literal(configName)));
         return new BuiltEntry(
-                Component.literal(key.path.get(key.path.size() - 1)),
+                Component.literal(configName),
                 key.comment.stream().map(Component::literal).collect(ImmutableList.toImmutableList()),
-                screen.display.createWidget(key, screen, old, x, y, width, height)
+                widget
         );
     }
 


### PR DESCRIPTION
On wider screens, and a lot of short config names, it can be really annoying to find out which checkbox is for which config value exactly. That's why this pull request adds a tooltip to each edit widget. That way, it's much easier to know if I edit the correct config value or the one above/below. 